### PR TITLE
Nibbles example and multi-write feature

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,21 +19,22 @@ All code must:
 - Be modern Rust code (currently 2018 edition, latest stable compiler)
 - Pass `cargo fmt` and `cargo clippy` (debug and release) with no warnings
 - Support required platforms: Linux, Mac, Windows, Web Assembly
+- Use only `crates.io`-published crates
 
 All code should:
 
-- Use only `crates.io`-published crates
-- Provide useful documentation
-- Expect future platforms: Android, iOS
 - Follow the [guidelines](https://rust-lang.github.io/api-guidelines/)
+- Provide useful documentation and comments, including private code
+- Expect future platforms: Android, iOS
 
 Most code should:
 
-- Create a new file or module for `struct`'s with non-trait `impl` blocks
-- Group all `use` statements into one nested `use` statement; where possible
+- Create a new file for `struct`'s with non-trait `impl` blocks
+- Group all `use` statements into one nested `use` statement; except for visibility modifiers and conditional compilation attributes
 - No star-style `use` statements except in demo code which is intended to be concise 
 - Prefer alphabetical sorting of code items unless there is a well-known non-alpha context
 - Use `// TODO` or `// HACK` comments as needed when breaking these guidelines
+- Make small `unsafe` blocks as needed, separating the safe and unsafe parts for clarity
 
 ### Human Requirements
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/attackgoat/screen-13"
 homepage = "https://github.com/attackgoat/screen-13"
-documentation = "http://doc.rust-lang.org/screen-13"
+documentation = "https://docs.rs/screen-13"
 keywords = ["gamedev" ]
 categories = ["game-engines"]
 description = """
@@ -34,9 +34,8 @@ log = "0.4"
 num-format = "0.4.0"
 pretty_env_logger = "0.4"
 
-# TODO: Baking deps here
+# TODO: Baking deps here https://github.com/rust-lang/cargo/issues/1982 maybe use features and [[bin]] required features?
 fbx_direct = "0.6"
-glob = "0.3"
 sha1 = "0.6"
 shaderc = "0.6"
 
@@ -44,8 +43,8 @@ shaderc = "0.6"
 lazy_static = "1.4"
 shaderc = "0.6"
 
-# [dev-dependencies]
-# TODO: Things for test and example code!
+[dev-dependencies]
+rand = "0.7"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
@@ -56,9 +55,9 @@ console_log = "0.2"
 version = "0.5"
 features = ["wgl"]
 
-[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
-version = "0.3"
-features = ["console", "Document", "Element", "HtmlElement", "Node", "Window"]
+# [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
+# version = "0.3"
+# features = ["console", "Document", "Element", "HtmlElement", "Node", "Window"]
 
 [target.'cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "linux", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 gfx-impl = { version = "0.5", features = ["x11"], package = "gfx-backend-vulkan" }

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ Asset baking is the industry-standard process of converting files from their nat
 
 ## Quick Start
 
-Included are four examples you might find helpful:
+Included are four examples you might find helpful, in order of complexity:
 
 - `basic.rs` - Displays 'Hello, World!' on the screen. Please start here.
-- `nibbles.rs` - A game built using lines as the only graphical element. (Not started yet)
+- `nibbles.rs` - A game built using lines as the only graphical element. (Done but engine doesn't draw yet)
 - `gorilla.rs` - A game demonstrating 2D bitmaps/tilemaps. (Not started yet)
 - `wasm.rs` - A 3D technology demonstration; runs in your web browser. (Not started yet)
 
 Each of these examples requires an associated asset `.pak` file in order to run, so you will need to run the examples like so:
 
-```
+```bash
 cargo run examples/content/basic.txt
 cargo run --example basic
 ```
@@ -41,6 +41,7 @@ This engine is very young and is likely to change as development continues.
 - Debug names should maybe be a Cargo.toml "feature" for games that aren't attempting to support debuggability via graphics API capturing tools such as RenderDoc. The way it is right now lots of API calls require a string you must attribute with the debug-assertions if-config attribute.
 - There are countless TODO's scattered in this codebase; this project started as a closed-source personal project and so Github issues and such for tracking things were not the original method I used. Feel free to replace TODO's by opening a matching Issue or just removing outdated TODO information.
 - Drawing lines, bitmaps, 3D models, lights (and shadows): I recently ripped out all this code in order to add a compilation stage after you submit rendering commands. This allows for proper z-order painting and batching to reduce GPU resource-switching. It is not complete yet and requires more work.
+- Input: Keyboard has been started but the design is not very good. Mouse input is to-do. Game controllers and joysticks are planned.
 
 ## History
 
@@ -51,7 +52,7 @@ CLS
 SCREEN 13
 ```
 
-These commands cleared the screen of text and setup a 320x200 256-color palletized color video mode. There were other video modes available, but none of them had the 'magic' of 256 colors.
+These commands cleared the screen of text and setup a 320x200 256-color paletized color video mode. There were other video modes available, but none of them had the 'magic' of 256 colors.
 
 Additional commands QBasic offered, such as `DRAW`, allowed you to build very simple games incredibly quickly because you didn't have to grok the enirety of linking and compiling in order get things done. I think we should have options like this today, and this project aims to allow future developers to have the same ability to get things done quickly while using modern tools.
 

--- a/examples/content/nibbles.txt
+++ b/examples/content/nibbles.txt
@@ -1,0 +1,2 @@
+TEXT fonts/small_10px.fnt
+fonts/small_10px_0.json

--- a/examples/gorilla.rs
+++ b/examples/gorilla.rs
@@ -1,3 +1,81 @@
+// Gorilla is a game for two players. Your mission is to hit your opponent with the exploding
+// banana by varying the angle and power of your throw, taking into account wind speed,
+// gravity, and the city skyline. I didn't have gorilla or banana graphics so we have bunnies
+// and bullets instead, sorry folks.
+
+use {
+    screen_13::{
+        gpu::{Bitmap, Font},
+        pak::Pak,
+        prelude::*,
+    },
+    std::io::{Read, Seek},
+};
+
+const SCREEN_SIZE: Extent = Extent::new(640, 400);
+
 fn main() -> ! {
     loop {}
+}
+
+enum BuildingType {
+    Brick,
+    Cement,
+}
+
+struct Building {
+    height: usize,
+    ty: BuildingType,
+}
+
+struct City {
+    atlas: Bitmap,
+    buildings: [Building; 12],
+}
+
+impl City {
+    fn load<R: Read + Seek>(gpu: &Gpu, pak: &Pak<R>) -> Self {
+        //Self {}
+        todo!()
+    }
+}
+
+struct Intro {
+    city: City,
+}
+
+impl Screen for Intro {
+    fn render(&self, gpu: &Gpu) -> Render {
+        let mut frame = gpu.render(
+            #[cfg(debug_assertions)]
+            "intro",
+            SCREEN_SIZE,
+        );
+
+        frame
+    }
+
+    fn update(mut self: Box<Self>, _: &Gpu, input: &Input) -> DynScreen {
+        self
+    }
+}
+
+struct Gorilla {
+    font: Font,
+}
+
+impl Screen for Gorilla {
+    fn render(&self, gpu: &Gpu) -> Render {
+        let mut frame = gpu.render(
+            #[cfg(debug_assertions)]
+            "gorilla render",
+            SCREEN_SIZE,
+        );
+
+        frame
+    }
+
+    fn update(mut self: Box<Self>, _: &Gpu, input: &Input) -> DynScreen {
+        self
+    }
 }

--- a/examples/nibbles.rs
+++ b/examples/nibbles.rs
@@ -1,3 +1,263 @@
+// Nibbles is a game for one player. There is only one level and the game only ends once your score
+// overflows an unsigned platform-wide integer on your machine. You play as Sammy the snake on an
+// 80x50 map bounded by a wall made of snake poison. To level up you must steer Sammy towards the
+// green colored food. Use the arrow keys to control Sammy and have fun!
+
+use {
+    rand::random,
+    screen_13::{
+        camera::Orthographic,
+        color::qb_color,
+        gpu::{Command, Font},
+        input::Key,
+        math::{vec3, Coord},
+        pak::Pak,
+        prelude::*,
+    },
+    std::{
+        env::current_exe,
+        io::{Read, Seek},
+        time::{Duration, Instant},
+    },
+};
+
+const THINK_TIME: Duration = Duration::from_millis(120);
+const SCREEN_SIZE: Extent = Extent::new(320, 200);
+
 fn main() -> ! {
-    loop {}
+    let engine = Engine::new(Program::new("nibbles"));
+    let mut pak = Pak::open(
+        current_exe()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("nibbles.pak"),
+    )
+    .expect("ERROR: You must first pack the game content into a file by running the following command: `cargo run examples/content/nibbles.txt`");
+
+    let nibbles = Box::new(Nibbles::load(engine.gpu(), &mut pak));
+
+    engine.run(nibbles);
+}
+
+enum Direction {
+    Down,
+    Left,
+    Right,
+    Up,
+}
+
+struct Nibbles {
+    direction: Direction,
+    font: Font,
+    food: Coord,
+    last_update: Instant,
+    sammy: Vec<Coord>,
+    score: usize,
+    view: Orthographic,
+}
+
+impl Nibbles {
+    fn load<R: Read + Seek>(gpu: &Gpu, mut pak: &mut Pak<R>) -> Self {
+        // We only need a font
+        let font = gpu.load_font(&mut pak, "small_10px");
+
+        // Setup an orthographic camera to provide a 2D view
+        let eye = vec3(SCREEN_SIZE.x as f32 * 0.5, SCREEN_SIZE.y as f32 * 0.5, -1.0);
+        let target = vec3(eye.x(), eye.y(), 0.0);
+        let view = Orthographic::new(
+            eye,
+            target,
+            0.0,
+            SCREEN_SIZE.x as f32,
+            SCREEN_SIZE.y as f32,
+            0.0,
+            -1.0,
+            1.0,
+        );
+
+        let mut game = Self {
+            direction: Direction::Right,
+            font,
+            food: Default::default(),
+            last_update: Instant::now(),
+            sammy: Default::default(),
+            score: Default::default(),
+            view,
+        };
+
+        // Setup the initial game state
+        game.reset();
+
+        game
+    }
+
+    fn detect_collision(&mut self) {
+        let sammy = *self.sammy.last().unwrap();
+
+        // Look for walls...
+        if sammy.x < 1 || sammy.x > 79 || sammy.y < 1 || sammy.y > 49 {
+            return self.reset();
+        }
+
+        // Make sure sammy doesn't get eaten
+        for idx in 0..self.sammy.len() - 1 {
+            if sammy == self.sammy[idx] {
+                self.reset()
+            }
+        }
+    }
+
+    fn detect_food(&mut self) {
+        let sammy_mouth = self.sammy.last().unwrap();
+        if *sammy_mouth == self.food {
+            self.move_food();
+            self.score += 1;
+        } else {
+            // TODO: Looks like a VecDequeue should be used here for `sammy`?
+            self.sammy.remove(0);
+        }
+    }
+
+    /// Picks a new spot to place the 'food' sammy so desperately seeks. Makes no attempt to place the food
+    /// on a non-sammy position.
+    fn move_food(&mut self) {
+        let x = random::<f32>() * 78.0;
+        let y = random::<f32>() * 48.0;
+        self.food = Coord::new(x as _, y as _);
+    }
+
+    fn move_sammy(&mut self, input: &Input) {
+        // Update Sammy's direction of movement
+        if input.keys.is_key_down(Key::Down) {
+            self.direction = Direction::Down;
+        } else if input.keys.is_key_down(Key::Left) {
+            self.direction = Direction::Left;
+        } else if input.keys.is_key_down(Key::Right) {
+            self.direction = Direction::Right;
+        } else if input.keys.is_key_down(Key::Up) {
+            self.direction = Direction::Up;
+        }
+
+        // Figure out where Sammy is moving next (this may be a wall or food!)
+        let last = self.sammy.last().unwrap();
+        let next = match self.direction {
+            Direction::Down => Coord::new(last.x, last.y + 1),
+            Direction::Left => Coord::new(last.x - 1, last.y),
+            Direction::Right => Coord::new(last.x + 1, last.y),
+            Direction::Up => Coord::new(last.x, last.y - 1),
+        };
+
+        self.sammy.push(next);
+    }
+
+    fn reset(&mut self) {
+        self.direction = Direction::Right;
+        self.sammy.clear();
+        self.score = 0;
+
+        // Put a medium-sized snake in the center of the arena
+        for x in -3..=3 {
+            self.sammy.push(Coord::new(x + 39, 24));
+        }
+
+        // Set an initial food position
+        self.move_food();
+    }
+}
+
+impl Screen for Nibbles {
+    fn render(&self, gpu: &Gpu) -> Render {
+        let mut frame = gpu.render(
+            #[cfg(debug_assertions)]
+            "nibbles",
+            SCREEN_SIZE,
+        );
+
+        // Blue background
+        frame.clear(qb_color(1));
+
+        // Player name on the left-top of the screen
+        frame.text(
+            #[cfg(debug_assertions)]
+            "player name",
+            &self.font,
+            "Player: Sammy",
+            Coord::new(2, 10),
+            qb_color(15),
+        );
+
+        // Score at the right-top of the screen
+        let score = format!("Score: {}", self.score);
+        let score_size = self.font.measure(&score);
+        frame.text(
+            #[cfg(debug_assertions)]
+            "score",
+            &self.font,
+            &score,
+            Coord::new(SCREEN_SIZE.x as i32 - score_size.x as i32 - 1, 10),
+            qb_color(15),
+        );
+
+        // Drawing commands for the arena (the deadly walls of death)...
+        let arena_color = qb_color(4);
+        let top_left = vec3(2.5, 12.5, 0.0);
+        let top_right = vec3(SCREEN_SIZE.x as f32 - 2.5, 12.5, 0.0);
+        let bottom_left = vec3(2.5, SCREEN_SIZE.y as f32 - 2.5, 0.0);
+        let bottom_right = vec3(SCREEN_SIZE.x as f32 - 2.5, SCREEN_SIZE.y as f32 - 2.5, 0.0);
+        let mut cmds = vec![
+            Command::line(top_left, arena_color, top_right, arena_color, 4.0),
+            Command::line(top_right, arena_color, bottom_right, arena_color, 4.0),
+            Command::line(bottom_right, arena_color, bottom_left, arena_color, 4.0),
+            Command::line(bottom_left, arena_color, top_left, arena_color, 4.0),
+        ];
+
+        // Drawing commands for sammy (the snake)...
+        let sammy_color = qb_color(14);
+        for seg in &self.sammy {
+            let start = vec3(seg.x as f32 * 4.0, seg.y as f32 * 4.0, 0.0);
+            let end = vec3(start.x() + 4.0, start.y() + 4.0, 0.0);
+            cmds.push(Command::line(start, sammy_color, end, sammy_color, 4.0));
+        }
+
+        // Drawing commands for the food...
+        let food_color = qb_color(10);
+        {
+            let start = vec3(self.food.x as f32 * 4.0, self.food.y as f32 * 4.0, 0.0);
+            let end = vec3(start.x() + 4.0, start.y() + 4.0, 0.0);
+            cmds.push(Command::line(start, food_color, end, food_color, 4.0));
+        }
+
+        // Send the Arena, Sammy, and Food as one batch. Lines will be drawn in the correct
+        // z-order given their 3D coordinates however in this case all lines have a Z of 0,
+        // so the order of submission is important - Food will be drawn last on top.
+        frame.draw(
+            #[cfg(debug_assertions)]
+            "arena and sammy",
+            &self.view,
+            &mut cmds,
+        );
+
+        // Present the completed frame to the screen
+        frame
+    }
+
+    fn update(mut self: Box<Self>, _: &Gpu, input: &Input) -> DynScreen {
+        // Note: This way of handling time stepping is beyond horrible, please do not
+        // copy this pattern! I did this to write less code not win hearts...
+        let elapsed = Instant::now() - self.last_update;
+        if elapsed > THINK_TIME {
+            self.last_update = Instant::now();
+
+            // Handle the game update logic
+            self.move_sammy(input);
+            self.detect_collision();
+            self.detect_food();
+        }
+
+        // Return `self` which makes sure we keep drawing/updating this screen only
+        self
+    }
 }

--- a/src/bake/bitmap.rs
+++ b/src/bake/bitmap.rs
@@ -2,12 +2,22 @@ use {
     super::{
         get_filename_key, get_path,
         pak_log::{LogId, PakLog},
-        schema::{Asset, BitmapAsset, FontBitmapAsset},
+        schema::{Asset, AtlasAsset, BitmapAsset, FontBitmapAsset},
     },
     crate::pak::{Bitmap, BitmapId, PakBuf},
     image::{buffer::ConvertBuffer, open as image_open, DynamicImage, RgbImage, RgbaImage},
     std::path::Path,
 };
+
+pub fn bake_atlas<P1: AsRef<Path>, P2: AsRef<Path>>(
+    _project_dir: P1,
+    _asset_filename: P2,
+    _altas_asset: &AtlasAsset,
+    _pak: &mut PakBuf,
+    _log: &mut PakLog,
+) -> BitmapId {
+    todo!();
+}
 
 pub fn bake_bitmap<P1: AsRef<Path>, P2: AsRef<Path>>(
     project_dir: P1,
@@ -110,30 +120,30 @@ fn pixels<P: AsRef<Path>>(filename: P, force_opaque: bool) -> (bool, u32, Vec<u8
 }
 
 fn pixels_bgr(image: &RgbImage) -> Vec<u8> {
-    let mut buffer = Vec::with_capacity(image.width() as usize * image.height() as usize * 3);
+    let mut buf = Vec::with_capacity(image.width() as usize * image.height() as usize * 3);
     for y in 0..image.height() {
         for x in 0..image.width() {
             let pixel = image.get_pixel(x, image.height() - y - 1);
-            buffer.push(pixel[2]);
-            buffer.push(pixel[1]);
-            buffer.push(pixel[0]);
+            buf.push(pixel[2]);
+            buf.push(pixel[1]);
+            buf.push(pixel[0]);
         }
     }
 
-    buffer
+    buf
 }
 
 fn pixels_bgra(image: &RgbaImage) -> Vec<u8> {
-    let mut buffer = Vec::with_capacity(image.width() as usize * image.height() as usize * 4);
+    let mut buf = Vec::with_capacity(image.width() as usize * image.height() as usize * 4);
     for y in 0..image.height() {
         for x in 0..image.width() {
             let pixel = image.get_pixel(x, image.height() - y - 1);
-            buffer.push(pixel[2]);
-            buffer.push(pixel[1]);
-            buffer.push(pixel[0]);
-            buffer.push(pixel[3]);
+            buf.push(pixel[2]);
+            buf.push(pixel[1]);
+            buf.push(pixel[0]);
+            buf.push(pixel[3]);
         }
     }
 
-    buffer
+    buf
 }

--- a/src/bake/lang.rs
+++ b/src/bake/lang.rs
@@ -1,14 +1,12 @@
 use {
     super::{
+        get_filename_key,
         pak_log::{LogId, PakLog},
         schema::{Asset, LanguageAsset},
     },
     crate::pak::PakBuf,
     std::path::Path,
 };
-
-#[cfg(debug_assertions)]
-use super::get_filename_key;
 
 pub fn bake_lang<P1: AsRef<Path>, P2: AsRef<Path>>(
     project_dir: P1,

--- a/src/bake/mesh.rs
+++ b/src/bake/mesh.rs
@@ -12,10 +12,7 @@ use {
         common::OwnedProperty,
         reader::{EventReader, FbxEvent},
     },
-    std::{
-        fs::File,
-        path::{Path, PathBuf},
-    },
+    std::{fs::File, path::Path},
 };
 
 pub fn bake_mesh<P1: AsRef<Path>, P2: AsRef<Path>>(

--- a/src/bake/mod.rs
+++ b/src/bake/mod.rs
@@ -8,7 +8,7 @@ mod schema;
 mod text;
 
 pub use self::{
-    bitmap::{bake_bitmap, bake_font_bitmap},
+    bitmap::{bake_atlas, bake_bitmap, bake_font_bitmap},
     blob::bake_blob,
     lang::bake_lang,
     mesh::bake_mesh,
@@ -18,10 +18,7 @@ pub use self::{
     text::bake_text,
 };
 
-use std::{
-    env::current_dir,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 // Gets the fully rooted asset path from a given path. If path is relative, then
 // dir is used to determine the relative parent.

--- a/src/bake/schema.rs
+++ b/src/bake/schema.rs
@@ -1,5 +1,5 @@
 use {
-    crate::math::{vec3, Vec3},
+    crate::math::{vec3, Coord, Rect, Vec3},
     serde::{Deserialize, Serialize},
     serde_json::{
         map::Map,
@@ -34,6 +34,7 @@ pub fn parse_vector3(value: &str) -> [f32; 3] {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub enum Asset {
+    Atlas(AtlasAsset),
     Bitmap(BitmapAsset),
     FontBitmap(FontBitmapAsset),
     Language(LanguageAsset),
@@ -58,14 +59,33 @@ impl Asset {
 
     fn parse_json(value: &Value) -> Self {
         match value["type"].as_str().unwrap() {
+            "ATLAS" => Asset::Atlas(AtlasAsset::parse_json(value)),
             "BITMAP" => Asset::Bitmap(BitmapAsset::parse_json(value)),
             "FONT_BITMAP" => Asset::FontBitmap(FontBitmapAsset::parse_json(value)),
-            "LOCALIZATION" => Asset::Language(LanguageAsset::parse_json(value)),
+            "LANGUAGE" => Asset::Language(LanguageAsset::parse_json(value)),
             "MESH" => Asset::Mesh(MeshAsset::parse_json(value)),
             "SCENE" => Asset::Scene(SceneAsset::parse_json(value)),
             _ => unimplemented!(),
         }
     }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct AtlasAsset {
+    tiles: Vec<AtlasTile>,
+}
+
+impl AtlasAsset {
+    fn parse_json(_value: &Value) -> Self {
+        todo!();
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct AtlasTile {
+    bitmap: PathBuf,
+    src: Rect,
+    dst: Coord,
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/src/camera/orthographic.rs
+++ b/src/camera/orthographic.rs
@@ -2,6 +2,8 @@ use crate::math::{Mat4, Vec3};
 
 use super::Camera;
 
+// TODO: Should creating a 2D camera (such as in the examples) be a constructor function?
+
 #[derive(Clone, Copy)]
 pub struct Orthographic {
     eye: Vec3,
@@ -12,10 +14,20 @@ pub struct Orthographic {
 }
 
 impl Orthographic {
-    pub fn new(eye: Vec3, proj: Mat4, target: Vec3) -> Self {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        eye: Vec3,
+        target: Vec3,
+        left: f32,
+        right: f32,
+        bottom: f32,
+        top: f32,
+        near: f32,
+        far: f32,
+    ) -> Self {
         let mut result = Self {
             eye,
-            proj,
+            proj: Mat4::orthographic_rh_gl(left, right, bottom, top, near, far),
             target,
             view: Mat4::identity(),
             view_inv: Mat4::identity(),

--- a/src/color/alpha.rs
+++ b/src/color/alpha.rs
@@ -30,7 +30,7 @@ impl AlphaColor {
         Self { b, g, r, a }
     }
 
-    pub fn to_rgba_f32(self) -> (f32, f32, f32, f32) {
+    pub fn to_unorm(self) -> (f32, f32, f32, f32) {
         (
             f32::from(self.r) / 255.0,
             f32::from(self.g) / 255.0,
@@ -39,8 +39,8 @@ impl AlphaColor {
         )
     }
 
-    pub fn to_rgba_unorm_u32_array(self) -> [u32; 4] {
-        let unorm = self.to_rgba_f32();
+    pub fn to_unorm_bits(self) -> [u32; 4] {
+        let unorm = self.to_unorm();
         [
             unorm.0.to_bits(),
             unorm.1.to_bits(),
@@ -69,7 +69,7 @@ impl From<Color> for AlphaColor {
 
 impl From<AlphaColor> for ClearValue {
     fn from(color: AlphaColor) -> Self {
-        let (r, g, b, a) = color.to_rgba_f32();
+        let (r, g, b, a) = color.to_unorm();
         Self {
             color: ClearColor {
                 float32: [r, g, b, a],

--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -76,7 +76,7 @@ impl From<ClearValue> for Color {
 impl From<Color> for ClearValue {
     fn from(color: Color) -> Self {
         let alpha_color: AlphaColor = color.into();
-        let (r, g, b, a) = alpha_color.to_rgba_f32();
+        let (r, g, b, a) = alpha_color.to_unorm();
         Self {
             color: ClearColor {
                 float32: [r, g, b, a],

--- a/src/fx/solid.rs
+++ b/src/fx/solid.rs
@@ -22,7 +22,7 @@ impl Screen for Solid {
         frame
     }
 
-    fn update(self: Box<Self>, gpu: &Gpu, input: &Input) -> DynScreen {
+    fn update(self: Box<Self>, _: &Gpu, _: &Input) -> DynScreen {
         self
     }
 }

--- a/src/gpu/data.rs
+++ b/src/gpu/data.rs
@@ -95,7 +95,7 @@ impl Data {
             Dependencies::empty(),
             &[Barrier::Buffer {
                 states: src_state.access_mask..Access::TRANSFER_READ,
-                target: src.0.as_ref(),
+                target: &*src.0,
                 families: None,
                 range: SubRange {
                     offset: range.start,
@@ -123,7 +123,7 @@ impl Data {
             Dependencies::empty(),
             &[Barrier::Buffer {
                 states: dst_state.access_mask..access_mask,
-                target: dst.0.as_ref(),
+                target: &*dst.0,
                 families: None,
                 range: SubRange {
                     offset: range.start,
@@ -202,7 +202,7 @@ impl Data {
     ) -> impl DerefMut<Target = [u8]> + 'a {
         let device = self.driver.borrow();
         let len = range.end - range.start;
-        let mem = self.cpu_buf.0.mem();
+        let mem = Buffer::mem(&self.cpu_buf.0);
         let ptr = device
             .map_memory(
                 mem,
@@ -257,7 +257,7 @@ impl Data {
                 families: None,
                 range: SubRange::WHOLE,
                 states: state.access_mask..access_mask,
-                target: buf.0.as_ref(),
+                target: &*buf.0,
             }],
         );
 
@@ -268,14 +268,6 @@ impl Data {
 
 impl AsRef<<_Backend as Backend>::Buffer> for Data {
     fn as_ref(&self) -> &<_Backend as Backend>::Buffer {
-        self.gpu_buf.0.as_ref()
-    }
-}
-
-impl Deref for Data {
-    type Target = <_Backend as Backend>::Buffer;
-
-    fn deref(&self) -> &Self::Target {
         &*self.gpu_buf.0
     }
 }

--- a/src/gpu/driver/graphics_pipeline.rs
+++ b/src/gpu/driver/graphics_pipeline.rs
@@ -8,7 +8,7 @@ use {
 #[derive(Debug)]
 pub struct GraphicsPipeline {
     driver: Driver,
-    graphics_pipeline: Option<<_Backend as Backend>::GraphicsPipeline>,
+    ptr: Option<<_Backend as Backend>::GraphicsPipeline>,
 }
 
 impl GraphicsPipeline {
@@ -20,24 +20,28 @@ impl GraphicsPipeline {
         #[cfg(debug_assertions)]
         debug!("Creating graphics pipeline '{}'", name);
 
-        let graphics_pipeline = unsafe {
-            driver
-                .as_ref()
-                .borrow()
-                .create_graphics_pipeline(&desc, None)
-        }
-        .unwrap(); // TODO: Use a pipeline cache?
+        let graphics_pipeline = {
+            let device = driver.borrow();
+
+            unsafe { device.create_graphics_pipeline(&desc, None) }.unwrap()
+        }; // TODO: Use a pipeline cache?
 
         Self {
             driver,
-            graphics_pipeline: Some(graphics_pipeline),
+            ptr: Some(graphics_pipeline),
         }
+    }
+}
+
+impl AsMut<<_Backend as Backend>::GraphicsPipeline> for GraphicsPipeline {
+    fn as_mut(&mut self) -> &mut <_Backend as Backend>::GraphicsPipeline {
+        &mut *self
     }
 }
 
 impl AsRef<<_Backend as Backend>::GraphicsPipeline> for GraphicsPipeline {
     fn as_ref(&self) -> &<_Backend as Backend>::GraphicsPipeline {
-        self.graphics_pipeline.as_ref().unwrap()
+        &*self
     }
 }
 
@@ -45,23 +49,23 @@ impl Deref for GraphicsPipeline {
     type Target = <_Backend as Backend>::GraphicsPipeline;
 
     fn deref(&self) -> &Self::Target {
-        self.graphics_pipeline.as_ref().unwrap()
+        self.ptr.as_ref().unwrap()
     }
 }
 
 impl DerefMut for GraphicsPipeline {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.graphics_pipeline.as_mut().unwrap()
+        self.ptr.as_mut().unwrap()
     }
 }
 
 impl Drop for GraphicsPipeline {
     fn drop(&mut self) {
+        let device = self.driver.borrow();
+        let ptr = self.ptr.take().unwrap();
+
         unsafe {
-            self.driver
-                .as_ref()
-                .borrow()
-                .destroy_graphics_pipeline(self.graphics_pipeline.take().unwrap());
+            device.destroy_graphics_pipeline(ptr);
         }
     }
 }

--- a/src/gpu/driver/image_view.rs
+++ b/src/gpu/driver/image_view.rs
@@ -13,7 +13,7 @@ use {
 #[derive(Debug)]
 pub struct ImageView {
     driver: Driver,
-    image_view: Option<<_Backend as Backend>::ImageView>,
+    ptr: Option<<_Backend as Backend>::ImageView>,
 }
 
 impl ImageView {
@@ -28,23 +28,28 @@ impl ImageView {
     where
         I: Deref<Target = <_Backend as Backend>::Image>,
     {
-        let image_view = unsafe {
-            driver
-                .borrow()
-                .create_image_view(&image, view_kind, format, swizzle, range)
-                .unwrap()
+        let image_view = {
+            let device = driver.borrow();
+
+            unsafe { device.create_image_view(&image, view_kind, format, swizzle, range) }.unwrap()
         };
 
         Self {
             driver,
-            image_view: Some(image_view),
+            ptr: Some(image_view),
         }
+    }
+}
+
+impl AsMut<<_Backend as Backend>::ImageView> for ImageView {
+    fn as_mut(&mut self) -> &mut <_Backend as Backend>::ImageView {
+        &mut *self
     }
 }
 
 impl AsRef<<_Backend as Backend>::ImageView> for ImageView {
     fn as_ref(&self) -> &<_Backend as Backend>::ImageView {
-        self.image_view.as_ref().unwrap()
+        &*self
     }
 }
 
@@ -52,22 +57,23 @@ impl Deref for ImageView {
     type Target = <_Backend as Backend>::ImageView;
 
     fn deref(&self) -> &Self::Target {
-        self.image_view.as_ref().unwrap()
+        self.ptr.as_ref().unwrap()
     }
 }
 
 impl DerefMut for ImageView {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.image_view.as_mut().unwrap()
+        self.ptr.as_mut().unwrap()
     }
 }
 
 impl Drop for ImageView {
     fn drop(&mut self) {
+        let device = self.driver.borrow();
+        let ptr = self.ptr.take().unwrap();
+
         unsafe {
-            self.driver
-                .borrow()
-                .destroy_image_view(self.image_view.take().unwrap());
+            device.destroy_image_view(ptr);
         }
     }
 }

--- a/src/gpu/driver/memory.rs
+++ b/src/gpu/driver/memory.rs
@@ -8,31 +8,43 @@ use {
 #[derive(Debug)]
 pub struct Memory {
     driver: Driver,
-    mem: Option<<_Backend as Backend>::Memory>,
+    ptr: Option<<_Backend as Backend>::Memory>,
     size: u64,
 }
 
 impl Memory {
-    pub fn new<M: Into<MemoryTypeId>>(driver: Driver, mem_type: M, size: u64) -> Self {
+    pub fn new<M: Into<MemoryTypeId>>(driver: Driver, mem_ty: M, size: u64) -> Self {
         #[cfg(debug_assertions)]
         assert_ne!(size, 0);
 
-        let mem = unsafe {
-            driver
-                .borrow()
-                .allocate_memory(mem_type.into(), size)
-                .unwrap()
+        let mem = {
+            let device = driver.borrow();
+            let mem_ty = mem_ty.into();
+
+            unsafe { device.allocate_memory(mem_ty, size) }.unwrap()
         };
 
         Self {
             driver,
-            mem: Some(mem),
+            ptr: Some(mem),
             size,
         }
     }
 
-    pub fn size(&self) -> u64 {
-        self.size
+    pub fn size(mem: &Self) -> u64 {
+        mem.size
+    }
+}
+
+impl AsMut<<_Backend as Backend>::Memory> for Memory {
+    fn as_mut(&mut self) -> &mut <_Backend as Backend>::Memory {
+        &mut *self
+    }
+}
+
+impl AsRef<<_Backend as Backend>::Memory> for Memory {
+    fn as_ref(&self) -> &<_Backend as Backend>::Memory {
+        &*self
     }
 }
 
@@ -40,22 +52,23 @@ impl Deref for Memory {
     type Target = <_Backend as Backend>::Memory;
 
     fn deref(&self) -> &Self::Target {
-        self.mem.as_ref().unwrap()
+        self.ptr.as_ref().unwrap()
     }
 }
 
 impl DerefMut for Memory {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.mem.as_mut().unwrap()
+        self.ptr.as_mut().unwrap()
     }
 }
 
 impl Drop for Memory {
     fn drop(&mut self) {
-        let mem = self.mem.take().unwrap();
+        let device = self.driver.borrow();
+        let ptr = self.ptr.take().unwrap();
 
         unsafe {
-            self.driver.borrow().free_memory(mem);
+            device.free_memory(ptr);
         }
     }
 }

--- a/src/gpu/driver/mod.rs
+++ b/src/gpu/driver/mod.rs
@@ -25,7 +25,7 @@ pub use self::{
     compute_pipeline::ComputePipeline,
     desc_pool::DescriptorPool,
     desc_set_layout::DescriptorSetLayout,
-    device::PhysicalDevice,
+    device::{Device, PhysicalDevice},
     fence::Fence,
     graphics_pipeline::GraphicsPipeline,
     help::{
@@ -45,7 +45,6 @@ pub use self::{
 
 use {
     self::{
-        device::Device,
         framebuffer::Framebuffer,
         image::{Dim, Image},
     },

--- a/src/gpu/driver/surface.rs
+++ b/src/gpu/driver/surface.rs
@@ -9,23 +9,35 @@ use {
 #[derive(Debug)]
 pub struct Surface {
     instance: Option<_InstanceImpl>,
-    surface: Option<<_Backend as Backend>::Surface>,
+    ptr: Option<<_Backend as Backend>::Surface>,
 }
 
 impl Surface {
     pub fn new(instance: _InstanceImpl, window: &Window) -> Result<Self, Error> {
         let surface = unsafe { instance.create_surface(window)? };
-        Surface::existing(Some(instance), surface)
+        Surface::with_surface(Some(instance), surface)
     }
 
-    pub fn existing(
+    pub fn with_surface(
         instance: Option<_InstanceImpl>,
         surface: <_Backend as Backend>::Surface,
     ) -> Result<Self, Error> {
         Ok(Self {
             instance,
-            surface: Some(surface),
+            ptr: Some(surface),
         })
+    }
+}
+
+impl AsMut<<_Backend as Backend>::Surface> for Surface {
+    fn as_mut(&mut self) -> &mut <_Backend as Backend>::Surface {
+        &mut *self
+    }
+}
+
+impl AsRef<<_Backend as Backend>::Surface> for Surface {
+    fn as_ref(&self) -> &<_Backend as Backend>::Surface {
+        &*self
     }
 }
 
@@ -33,21 +45,23 @@ impl Deref for Surface {
     type Target = <_Backend as Backend>::Surface;
 
     fn deref(&self) -> &Self::Target {
-        self.surface.as_ref().unwrap()
+        self.ptr.as_ref().unwrap()
     }
 }
 
 impl DerefMut for Surface {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.surface.as_mut().unwrap()
+        self.ptr.as_mut().unwrap()
     }
 }
 
 impl Drop for Surface {
     fn drop(&mut self) {
         if let Some(instance) = &self.instance {
+            let ptr = self.ptr.take().unwrap();
+
             unsafe {
-                instance.destroy_surface(self.surface.take().unwrap());
+                instance.destroy_surface(ptr);
             }
         }
     }

--- a/src/gpu/glsl/blending/quad_transform.vert
+++ b/src/gpu/glsl/blending/quad_transform.vert
@@ -3,7 +3,7 @@
 layout(location = 1) out vec2 texcoord_base_out;
 
 void main() {
-    texcoord_base_out = get_texcoord();
-    texcoord_out = get_texcoord();
-    gl_Position = push_constants.transform * vec4(texcoord_out, 0, 1);
+    texcoord_base_out = vertex();
+    texcoord_out = texcoord_base_out * push_constants.texcoord_scale + push_constants.texcoord_offset;
+    gl_Position = push_constants.vertex_transform * vec4(texcoord_base_out, 0, 1);
 }

--- a/src/gpu/glsl/quad_transform.glsl
+++ b/src/gpu/glsl/quad_transform.glsl
@@ -4,10 +4,13 @@ const float X[6] = {0, 1, 0, 1, 0, 1};
 const float Y[6] = {0, 0, 1, 1, 1, 0};
 
 layout(push_constant) uniform PushConstants {
-    layout(offset = 0) mat4x4 transform;
+    layout(offset = 0) vec2 texcoord_offset;
+    layout(offset = 8) vec2 texcoord_scale;
+    layout(offset = 16) mat4x4 vertex_transform;
 }
 push_constants;
 
 layout(location = 0) out vec2 texcoord_out;
 
-vec2 get_texcoord() { return vec2(X[gl_VertexIndex], Y[gl_VertexIndex]); }
+// Returns the quad billboard coordinate for the current vertex. This quad is placed at (0,0) and evenly textures to (1,1).
+vec2 vertex() { return vec2(X[gl_VertexIndex], Y[gl_VertexIndex]); }

--- a/src/gpu/glsl/quad_transform.vert
+++ b/src/gpu/glsl/quad_transform.vert
@@ -1,6 +1,6 @@
 #include "quad_transform.glsl"
 
 void main() {
-    texcoord_out = get_texcoord();
-    gl_Position = push_constants.transform * vec4(texcoord_out, 0, 1);
+    texcoord_out = vertex() * push_constants.texcoord_scale + push_constants.texcoord_offset;
+    gl_Position = push_constants.vertex_transform * vec4(vertex(), 0, 1);
 }

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,12 +1,22 @@
 mod data;
+
+/// A collection of smart-pointer types used internally to operate the GFX-HAL API.
 mod driver;
+
+/// A collection of operation implementations mostly used internally to fulfill the Render API.
 mod op;
+
+/// A collection of resource pool types used internally to cache GFX-HAL types.
 mod pool;
+
 mod render;
 mod texture;
 
 pub use self::{
-    op::{Bitmap, BlendMode, Font, Material, WriteMode},
+    op::{
+        draw::{Command, LineCommand, LineVertex, Material},
+        Bitmap, Font, Write, WriteMode,
+    },
     render::{Operation, Render},
     texture::Texture,
 };
@@ -78,6 +88,35 @@ fn create_adapter_surface(window: &Window) -> (Adapter<_Backend>, Surface) {
     let (adapter, instance) = create_adapter();
     let surface = Surface::new(instance, window).unwrap();
     (adapter, surface)
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum BlendMode {
+    Add,
+    Alpha,
+    ColorBurn,
+    ColorDodge,
+    Color,
+    Darken,
+    DarkenColor,
+    Difference,
+    Divide,
+    Exclusion,
+    HardLight,
+    HardMix,
+    LinearBurn,
+    Multiply,
+    Normal,
+    Overlay,
+    Screen,
+    Subtract,
+    VividLight,
+}
+
+impl Default for BlendMode {
+    fn default() -> Self {
+        Self::Normal
+    }
 }
 
 /// Allows you to load resources and begin rendering operations.

--- a/src/gpu/op/draw/compiler.rs
+++ b/src/gpu/op/draw/compiler.rs
@@ -46,7 +46,7 @@ impl<'c> Iterator for Compilation<'c, '_> {
     type Item = Instruction<'c>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        None
+        Some(Self::Item::Stop)
     }
 }
 
@@ -86,7 +86,7 @@ impl Compiler {
 
         Compilation {
             compiler: self,
-            idx: 0,
+            idx,
             mesh_refs,
             mesh_sets: Default::default(),
             stages: Stages::empty(),
@@ -251,6 +251,7 @@ where
     cmds
 }*/
 
+// TODO: This is fun but completely not needed; should just store a few bools and move on with life?
 bitflags! {
     /// NOTE: I don't bother adding the mesh types here because the only usage of this
     /// is to detect the need to instantiate graphics pipelines; however for the mesh

--- a/src/gpu/op/mod.rs
+++ b/src/gpu/op/mod.rs
@@ -1,7 +1,8 @@
+pub(crate) mod draw;
+
 mod bitmap;
 mod clear;
 mod copy;
-mod draw;
 mod encode;
 mod font;
 mod gradient;
@@ -11,71 +12,35 @@ pub use self::{
     bitmap::{Bitmap, BitmapOp},
     clear::ClearOp,
     copy::CopyOp,
-    draw::{Command, Compiler, DrawOp, Material},
+    //draw::{Command, Compiler, DrawOp, Material},
     encode::EncodeOp,
     font::{Font, FontOp},
     gradient::GradientOp,
-    write::{BlendMode, Mode as WriteMode, WriteOp},
+    write::{Mode as WriteMode, Write, WriteOp},
 };
 
 use {
-    crate::math::{Mat3, Mat4},
     gfx_hal::{device::Device as _, Backend},
     gfx_impl::Backend as _Backend,
-    std::time::Instant,
 };
 
-pub(self) fn mat4_to_u32_array(m: Mat4) -> [u32; 16] {
-    let m = m.to_cols_array();
-    [
-        m[0].to_bits(),
-        m[1].to_bits(),
-        m[2].to_bits(),
-        m[3].to_bits(),
-        m[4].to_bits(),
-        m[5].to_bits(),
-        m[6].to_bits(),
-        m[7].to_bits(),
-        m[8].to_bits(),
-        m[9].to_bits(),
-        m[10].to_bits(),
-        m[11].to_bits(),
-        m[12].to_bits(),
-        m[13].to_bits(),
-        m[14].to_bits(),
-        m[15].to_bits(),
-    ]
-}
+#[cfg(debug_assertions)]
+use std::time::Instant;
 
-pub(self) fn mat4_to_mat3_u32_array(m: Mat4) -> [u32; 9] {
-    let m = m.to_cols_array();
-    [
-        m[0].to_bits(),
-        m[1].to_bits(),
-        m[2].to_bits(),
-        m[5].to_bits(),
-        m[6].to_bits(),
-        m[7].to_bits(),
-        m[9].to_bits(),
-        m[10].to_bits(),
-        m[11].to_bits(),
-    ]
-}
-
-pub(self) fn mat3_to_u32_array(m: Mat3) -> [u32; 9] {
-    let m = m.to_cols_array();
-    [
-        m[0].to_bits(),
-        m[1].to_bits(),
-        m[2].to_bits(),
-        m[3].to_bits(),
-        m[4].to_bits(),
-        m[5].to_bits(),
-        m[6].to_bits(),
-        m[7].to_bits(),
-        m[8].to_bits(),
-    ]
-}
+// pub(self) fn mat4_to_mat3_u32_array(val: Mat4) -> [u32; 9] {
+//     let val = val.to_cols_array();
+//     [
+//         val[0].to_bits(),
+//         val[1].to_bits(),
+//         val[2].to_bits(),
+//         val[5].to_bits(),
+//         val[6].to_bits(),
+//         val[7].to_bits(),
+//         val[9].to_bits(),
+//         val[10].to_bits(),
+//         val[11].to_bits(),
+//     ]
+// }
 
 pub(self) unsafe fn wait_for_fence(
     device: &<_Backend as Backend>::Device,
@@ -91,6 +56,7 @@ pub(self) unsafe fn wait_for_fence(
     {
         let started = Instant::now();
 
+        // TODO: Improve later
         for _ in 0..100 {
             if let Ok(true) | Err(_) = device.wait_for_fence(fence, 1_000_000) {
                 let elapsed = Instant::now() - started;

--- a/src/gpu/op/write.rs
+++ b/src/gpu/op/write.rs
@@ -1,20 +1,20 @@
 use {
-    super::{mat4_to_u32_array, wait_for_fence, Op},
+    super::{wait_for_fence, Op},
     crate::{
         color::TRANSPARENT_BLACK,
         gpu::{
             driver::{
-                bind_graphics_descriptor_set, CommandPool, Driver, Fence, Framebuffer2d, Image2d,
+                bind_graphics_descriptor_set, CommandPool, Device, Driver, Fence, Framebuffer2d,
                 PhysicalDevice,
             },
             pool::{Graphics, GraphicsMode, Lease, RenderPassMode},
-            PoolRef, TextureRef,
+            BlendMode, PoolRef, Texture2d, TextureRef,
         },
-        math::Mat4,
+        math::{vec3, Area, CoordF, Mat4, RectF, Vec2},
     },
     gfx_hal::{
         command::{CommandBuffer as _, CommandBufferFlags, ImageCopy, Level, SubpassContents},
-        device::Device,
+        device::Device as _,
         format::Aspects,
         image::{Access, Layout, Offset, SubresourceLayers, Tiling, Usage},
         pool::CommandPool as _,
@@ -31,76 +31,122 @@ use {
 
 const QUEUE_TYPE: QueueType = QueueType::Graphics;
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum BlendMode {
-    Add,
-    Alpha,
-    ColorBurn,
-    ColorDodge,
-    Color,
-    Darken,
-    DarkenColor,
-    Difference,
-    Divide,
-    Exclusion,
-    HardLight,
-    HardMix,
-    LinearBurn,
-    Multiply,
-    Normal,
-    Overlay,
-    Screen,
-    Subtract,
-    VividLight,
-}
-
-impl Default for BlendMode {
-    fn default() -> Self {
-        Self::Normal
-    }
-}
-
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Hash, PartialEq)]
 pub enum Mode {
     Blend((u8, BlendMode)),
     Texture,
 }
 
-pub struct WriteOp<S, D>
+#[repr(C)]
+struct VertexConsts {
+    offset: Vec2,
+    scale: Vec2,
+    transform: Mat4,
+}
+
+impl AsRef<[u32; 20]> for VertexConsts {
+    #[inline]
+    fn as_ref(&self) -> &[u32; 20] {
+        unsafe { &*(self as *const Self as *const [u32; 20]) }
+    }
+}
+
+/// An expressive type which allows specification of individual texture writes. Texture writes may either specify the
+/// entire source texture or a tile sub-portion. Tiles are always specified using integer texel coordinates.
+pub struct Write<'s> {
+    src: &'s Texture2d,
+    src_region: Area,
+    transform: Mat4,
+}
+
+impl<'s> Write<'s> {
+    /// Writes the whole source texture to the destination at the given position.
+    pub fn position<D: Into<CoordF>>(src: &'s Texture2d, dst: D) -> Self {
+        Self::tile_position(src, src.borrow().dims().into(), dst)
+    }
+
+    /// Writes the whole source texture to the destination at the given rectangle.
+    pub fn region<D: Into<RectF>>(src: &'s Texture2d, dst: D) -> Self {
+        Self::tile_region(src, src.borrow().dims().into(), dst)
+    }
+
+    /// Writes a tile area of the source texture to the destination at the given position.
+    pub fn tile_position<D: Into<CoordF>>(src: &'s Texture2d, src_tile: Area, dst: D) -> Self {
+        Self::tile_region(
+            src,
+            src_tile,
+            RectF {
+                dims: src.borrow().dims().into(),
+                pos: dst.into(),
+            },
+        )
+    }
+
+    /// Writes a tile area of the source texture to the destination at the given rectangle.
+    pub fn tile_region<D: Into<RectF>>(src: &'s Texture2d, src_tile: Area, dst: D) -> Self {
+        let dst = dst.into();
+        let src_dims: CoordF = src.borrow().dims().into();
+        let dst_transform = Mat4::from_translation(vec3(-1.0, -1.0, 0.0))
+            * Mat4::from_scale(vec3(
+                dst.dims.x * 2.0 / src_dims.x,
+                dst.dims.y * 2.0 / src_dims.y,
+                1.0,
+            ))
+            * Mat4::from_translation(vec3(dst.pos.x / dst.dims.x, dst.pos.y / dst.dims.y, 0.0));
+
+        Self::tile_transform(src, src_tile, dst_transform)
+    }
+
+    /// Writes a tile area of the source texture to the destination using the given transformation matrix.
+    pub fn tile_transform(src: &'s Texture2d, src_tile: Area, dst: Mat4) -> Self {
+        Self {
+            src,
+            src_region: src_tile,
+            transform: dst,
+        }
+    }
+
+    /// Writes the whole source texture to the destination using the given transformation matrix.
+    pub fn transform(src: &'s Texture2d, dst: Mat4) -> Self {
+        Self::tile_transform(src, src.borrow().dims().into(), dst)
+    }
+}
+
+pub struct WriteOp<D>
 where
-    S: AsRef<<_Backend as Backend>::Image>,
     D: AsRef<<_Backend as Backend>::Image>,
 {
-    back_buf: Lease<TextureRef<Image2d>>,
+    back_buf: Lease<Texture2d>,
     cmd_buf: <_Backend as Backend>::CommandBuffer,
     cmd_pool: Lease<CommandPool>,
     dst: TextureRef<D>,
     dst_layout: Option<(Layout, PipelineStage, Access)>,
+    dst_preserve: bool,
     fence: Lease<Fence>,
     frame_buf: Option<Framebuffer2d>,
-    graphics: Option<(Mode, Lease<Graphics>)>,
+    graphics: Option<Lease<Graphics>>,
+    mode: Mode,
     #[cfg(debug_assertions)]
     name: String,
     pool: PoolRef,
-    preserve_dst: bool,
-    src: TextureRef<S>,
-    transform: Mat4,
+    src_textures: Vec<Texture2d>,
 }
 
-// TODO: Make this take a list of arguments, not just one texture/mode/transform
-impl<S, D> WriteOp<S, D>
+impl<D> WriteOp<D>
 where
-    S: AsRef<<_Backend as Backend>::Image>,
     D: AsRef<<_Backend as Backend>::Image>,
 {
     pub fn new(
         #[cfg(debug_assertions)] name: &str,
         pool: &PoolRef,
-        src: &TextureRef<S>,
         dst: &TextureRef<D>,
+        mode: Mode,
     ) -> Self {
         let mut pool_ref = pool.borrow_mut();
-        let family = pool_ref.driver().borrow().get_queue_family(QUEUE_TYPE);
+        let family = {
+            let device = pool_ref.driver().borrow();
+            Device::queue_family(&device, QUEUE_TYPE)
+        };
         let mut cmd_pool = pool_ref.cmd_pool(family);
 
         Self {
@@ -123,113 +169,121 @@ where
             cmd_pool,
             dst: TextureRef::clone(dst),
             dst_layout: None,
+            dst_preserve: false,
             fence: pool_ref.fence(),
             frame_buf: None,
             graphics: None,
+            mode,
             #[cfg(debug_assertions)]
             name: name.to_owned(),
             pool: PoolRef::clone(pool),
-            preserve_dst: false,
-            src: TextureRef::clone(src),
-            transform: Mat4::identity(),
+            src_textures: Default::default(),
         }
     }
 
-    pub fn with_dst_layout(mut self, layout: Layout, stage: PipelineStage, access: Access) -> Self {
+    /// Sets the destination texture to the given layout after all writes are completed.
+    pub fn with_layout(mut self, layout: Layout, stage: PipelineStage, access: Access) -> Self {
         self.dst_layout = Some((layout, stage, access));
         self
     }
 
-    pub fn with_mode(mut self, mode: Mode) -> Self {
-        unsafe {
-            self.set_mode(mode);
-        }
+    /// Preserves the contents of the destination texture. Without calling this function the existing
+    /// contents of the destination texture will not be composited into the final result.
+    pub fn with_preserve(mut self) -> Self {
+        self.dst_preserve = true;
         self
     }
 
-    pub fn with_preserve_dst(mut self) -> Self {
-        self.preserve_dst = true;
+    pub fn record(mut self, writes: &mut [Write]) -> impl Op {
+        assert_ne!(writes.len(), 0);
 
-        // Graphics mode relies on preserve_dst to determine render pass, so we must update it
-        let mode = if let Some((mode, _)) = self.graphics.as_ref() {
-            Some(*mode)
+        if writes.len() > 1 {
+            // This closure returns the index of a given texture in our `source texture` list.
+            let mut src_idx = |src: &Texture2d| -> usize {
+                let len = self.src_textures.len();
+                for idx in 0..len {
+                    if TextureRef::ptr_eq(src, &self.src_textures[idx]) {
+                        return idx;
+                    }
+                }
+
+                // Not in the list - add and return the new index
+                self.src_textures.push(TextureRef::clone(src));
+                len
+            };
+
+            // Sort the writes by texture so that we minimize the number of descriptor sets and how often we change sets during submit
+            // NOTE: Unstable sort because we don't claim to support ordering or blending of the individual writes within each batch
+            // TODO: When the Rust `weak_into_raw` feature lands in stable we can replace this with more efficient `Rc::as_ptr`-based
+            // logic and do pointer compares as opposed to searching the entire list to find equality (that part is above)
+            writes.sort_unstable_by(|lhs, rhs| {
+                let lhs_idx = src_idx(&lhs.src);
+                let rhs_idx = src_idx(&rhs.src);
+                lhs_idx.cmp(&rhs_idx)
+            });
         } else {
-            None
-        };
-        if let Some(mode) = mode {
-            unsafe {
-                self.set_mode(mode);
-            }
+            // We only have one write - and the above sort logic would not be called (there would be no right-hand-side!)
+            self.src_textures.push(TextureRef::clone(writes[0].src));
         }
 
-        self
-    }
-
-    pub fn with_transform(mut self, transform: Mat4) -> Self {
-        self.transform = transform;
-        self
-    }
-
-    pub fn record(mut self) -> impl Op {
-        // If no write mode was selected we use `Copy`
-        if self.graphics.is_none() {
-            //self.set_mode(Mode::Fill);
-            todo!();
-        }
-
-        // Setup the framebuffer
+        // Final setup bits
         {
             let mut pool = self.pool.borrow_mut();
             let driver = Driver::clone(pool.driver());
+
+            // Setup the framebuffer
             self.frame_buf.replace(Framebuffer2d::new(
                 Driver::clone(&driver),
                 pool.render_pass(self.render_pass_mode()),
                 once(self.back_buf.borrow().as_default_2d_view().as_ref()),
                 self.dst.borrow().dims(),
             ));
+
+            // Setup the graphics pipeline(s) using one descriptor set per unique source texture
+            let graphics_mode = match self.mode {
+                Mode::Blend((_, mode)) => GraphicsMode::Blend(mode),
+                Mode::Texture => GraphicsMode::Texture,
+            };
+            self.graphics.replace(pool.graphics_sets(
+                #[cfg(debug_assertions)]
+                &self.name,
+                graphics_mode,
+                self.render_pass_mode(),
+                0,
+                self.src_textures.len(),
+            ));
         }
 
         unsafe {
             self.write_descriptor_sets();
-            self.submit();
+            self.submit_begin();
+
+            let mut set_idx = 0;
+            for write in writes.iter() {
+                self.submit_write(write, &mut set_idx);
+            }
+
+            self.submit_finish();
         };
 
-        WriteResult { op: self }
+        self
     }
 
     fn render_pass_mode(&self) -> RenderPassMode {
-        if self.preserve_dst {
+        if self.dst_preserve {
             RenderPassMode::ReadWrite
         } else {
             RenderPassMode::Write
         }
     }
 
-    unsafe fn set_mode(&mut self, mode: Mode) {
-        let graphics_mode = match mode {
-            Mode::Blend((_, mode)) => GraphicsMode::Blend(mode),
-            Mode::Texture => GraphicsMode::Texture,
-        };
-        self.graphics = Some((
-            mode,
-            self.pool.borrow_mut().graphics(
-                #[cfg(debug_assertions)]
-                &self.name,
-                graphics_mode,
-                self.render_pass_mode(),
-                0,
-            ),
-        ));
-    }
-
-    unsafe fn submit(&mut self) {
+    unsafe fn submit_begin(&mut self) {
         let mut pool = self.pool.borrow_mut();
-        let (mode, graphics) = self.graphics.as_ref().unwrap();
         let mut back_buf = self.back_buf.borrow_mut();
-        let mut src = self.src.borrow_mut();
         let mut dst = self.dst.borrow_mut();
+        let graphics = self.graphics.as_ref().unwrap();
         let dims = dst.dims();
-        let rect = dims.as_rect();
+        let rect = dims.into();
         let viewport = Viewport {
             rect,
             depth: 0.0..1.0,
@@ -240,7 +294,7 @@ where
             .begin_primary(CommandBufferFlags::ONE_TIME_SUBMIT);
 
         // Optional step: Fill dst into the backbuffer in order to preserve it in the output
-        if self.preserve_dst {
+        if self.dst_preserve {
             dst.set_layout(
                 &mut self.cmd_buf,
                 Layout::TransferSrcOptimal,
@@ -289,12 +343,12 @@ where
             PipelineStage::COLOR_ATTACHMENT_OUTPUT,
             Access::COLOR_ATTACHMENT_WRITE,
         );
-        src.set_layout(
-            &mut self.cmd_buf,
-            Layout::ShaderReadOnlyOptimal,
-            PipelineStage::FRAGMENT_SHADER,
-            Access::SHADER_READ,
-        );
+        // src.set_layout(
+        //     &mut self.cmd_buf,
+        //     Layout::ShaderReadOnlyOptimal,
+        //     PipelineStage::FRAGMENT_SHADER,
+        //     Access::SHADER_READ,
+        // );
         self.cmd_buf.begin_render_pass(
             pool.render_pass(self.render_pass_mode()),
             self.frame_buf.as_ref().unwrap(),
@@ -303,25 +357,58 @@ where
             SubpassContents::Inline,
         );
         self.cmd_buf.bind_graphics_pipeline(graphics.pipeline());
+        self.cmd_buf.set_scissors(0, &[rect]);
+        self.cmd_buf.set_viewports(0, &[viewport]);
+        bind_graphics_descriptor_set(&mut self.cmd_buf, graphics.layout(), graphics.desc_set(0));
+    }
+
+    unsafe fn submit_write(&mut self, write: &Write, set_idx: &mut usize) {
+        let graphics = self.graphics.as_ref().unwrap();
+        let layout = graphics.layout();
+
+        // If this write (writes are sorted identically to `self.src_textures` except the writes have more items) is a different
+        // texture we will need to switch to the next descriptor set - this won't happen on the first write of course.
+        if !Texture2d::ptr_eq(write.src, &self.src_textures[*set_idx]) {
+            *set_idx += 1;
+            bind_graphics_descriptor_set(&mut self.cmd_buf, layout, graphics.desc_set(*set_idx));
+        }
+
+        let offset = Vec2::zero();
+        let scale = Vec2::one();
         self.cmd_buf.push_graphics_constants(
             graphics.layout(),
             ShaderStageFlags::VERTEX,
             0,
-            &mat4_to_u32_array(self.transform),
+            VertexConsts {
+                offset,
+                scale,
+                transform: write.transform,
+            }
+            .as_ref(),
         );
-        if let Mode::Blend((ab, _)) = mode {
-            let ab = *ab as f32 / u8::MAX as f32;
+
+        if let Mode::Blend((ab, _)) = self.mode {
+            let ab = ab as f32 / u8::MAX as f32;
+            let inv = 1.0 - ab;
             self.cmd_buf.push_graphics_constants(
                 graphics.layout(),
                 ShaderStageFlags::FRAGMENT,
                 64,
-                &[(ab).to_bits(), (1.0 - ab).to_bits()],
+                &[ab.to_bits(), inv.to_bits()],
             );
         }
-        bind_graphics_descriptor_set(&mut self.cmd_buf, graphics.layout(), graphics.desc_set(0));
-        self.cmd_buf.set_scissors(0, &[rect]);
-        self.cmd_buf.set_viewports(0, &[viewport]);
+
         self.cmd_buf.draw(0..6, 0..1);
+    }
+
+    unsafe fn submit_finish(&mut self) {
+        let pool = self.pool.borrow_mut();
+        let mut device = pool.driver().borrow_mut();
+        let mut back_buf = self.back_buf.borrow_mut();
+        let mut dst = self.dst.borrow_mut();
+        let dims = dst.dims();
+
+        // End of the previous step...
         self.cmd_buf.end_render_pass();
 
         // Step 2: Copy the now-composited backbuffer to the `dst` texture
@@ -367,83 +454,70 @@ where
         // Finish
         self.cmd_buf.finish();
 
-        pool.driver().borrow_mut().get_queue_mut(QUEUE_TYPE).submit(
+        Device::queue_mut(&mut device, QUEUE_TYPE).submit(
             Submission {
                 command_buffers: once(&self.cmd_buf),
                 wait_semaphores: empty(),
                 signal_semaphores: empty::<&<_Backend as Backend>::Semaphore>(),
             },
-            Some(self.fence.as_ref()),
+            Some(&self.fence),
         );
     }
 
     unsafe fn write_descriptor_sets(&mut self) {
-        let (mode, graphics) = self.graphics.as_ref().unwrap();
-        let src = self.src.borrow();
         let dst = self.dst.borrow();
-        let src_view = src.as_default_2d_view();
+        let dst_view = dst.as_default_2d_view();
+        let graphics = self.graphics.as_ref().unwrap();
+        let sampler = graphics.sampler(0).as_ref();
 
-        if let Mode::Blend(_) = mode {
-            let dst_view = dst.as_default_2d_view();
-            self.pool
-                .borrow()
-                .driver()
-                .borrow_mut()
-                .write_descriptor_sets(
-                    vec![
-                        DescriptorSetWrite {
-                            set: graphics.desc_set(0),
-                            binding: 0,
-                            array_offset: 0,
-                            descriptors: once(Descriptor::CombinedImageSampler(
-                                src_view.as_ref(),
-                                Layout::ShaderReadOnlyOptimal,
-                                graphics.sampler(0).as_ref(),
-                            )),
-                        },
-                        DescriptorSetWrite {
-                            set: graphics.desc_set(0),
-                            binding: 1,
-                            array_offset: 0,
-                            descriptors: once(Descriptor::CombinedImageSampler(
-                                dst_view.as_ref(),
-                                Layout::ShaderReadOnlyOptimal,
-                                graphics.sampler(0).as_ref(),
-                            )),
-                        },
-                    ]
-                    .drain(..),
-                );
-        } else {
-            self.pool
-                .borrow()
-                .driver()
-                .borrow_mut()
-                .write_descriptor_sets(once(DescriptorSetWrite {
-                    set: graphics.desc_set(0),
-                    binding: 0,
+        // Each source texture requres a unique descriptor set
+        for (idx, src) in self.src_textures.iter().enumerate() {
+            let set = graphics.desc_set(idx);
+
+            // A descriptor for this source texture
+            let src_ref = src.borrow();
+            let src_view = src_ref.as_default_2d_view();
+            let src_desc = DescriptorSetWrite {
+                set,
+                binding: 0,
+                array_offset: 0,
+                descriptors: once(Descriptor::CombinedImageSampler(
+                    &**src_view,
+                    Layout::ShaderReadOnlyOptimal,
+                    sampler,
+                )),
+            };
+
+            // Blend mode requires a descriptor for the destination texture
+            if let Mode::Blend(_) = self.mode {
+                let dst_desc = DescriptorSetWrite {
+                    set,
+                    binding: 1,
                     array_offset: 0,
                     descriptors: once(Descriptor::CombinedImageSampler(
-                        src_view.as_ref(),
+                        &**dst_view,
                         Layout::ShaderReadOnlyOptimal,
-                        graphics.sampler(0).as_ref(),
+                        sampler,
                     )),
-                }));
+                };
+                self.pool
+                    .borrow()
+                    .driver()
+                    .borrow_mut()
+                    .write_descriptor_sets(vec![src_desc, dst_desc]);
+            } else {
+                self.pool
+                    .borrow()
+                    .driver()
+                    .borrow_mut()
+                    .write_descriptor_sets(once(src_desc));
+            }
         }
     }
 }
 
-struct WriteResult<S, D>
+impl<D> Drop for WriteOp<D>
 where
-    S: AsRef<<_Backend as Backend>::Image>,
-    D: AsRef<<_Backend as Backend>::Image>,
-{
-    op: WriteOp<S, D>,
-}
-
-impl<S, D> Drop for WriteResult<S, D>
-where
-    S: AsRef<<_Backend as Backend>::Image>,
     D: AsRef<<_Backend as Backend>::Image>,
 {
     fn drop(&mut self) {
@@ -451,14 +525,16 @@ where
     }
 }
 
-impl<S, D> Op for WriteResult<S, D>
+impl<D> Op for WriteOp<D>
 where
-    S: AsRef<<_Backend as Backend>::Image>,
     D: AsRef<<_Backend as Backend>::Image>,
 {
     fn wait(&self) {
+        let pool = self.pool.borrow();
+        let device = pool.driver().borrow();
+
         unsafe {
-            wait_for_fence(&*self.op.pool.borrow().driver().borrow(), &self.op.fence);
+            wait_for_fence(&device, &self.fence);
         }
     }
 }

--- a/src/gpu/pool/graphics.rs
+++ b/src/gpu/pool/graphics.rs
@@ -1,3 +1,5 @@
+// TODO: This file is way too repetitive with similar code blocks all over the place. It could use some lovin'.
+
 use {
     super::spirv::{
         blending::{
@@ -137,14 +139,17 @@ impl Graphics {
         );
         let layout = PipelineLayout::new(
             Driver::clone(&driver),
-            once(set_layout.as_ref()),
+            once(&*set_layout),
             &[
                 (ShaderStageFlags::VERTEX, 0..64),
                 (ShaderStageFlags::FRAGMENT, 64..72),
             ],
         );
         let mut desc = GraphicsPipelineDesc::new(
-            shader_set(vertex.entry_point(), fragment.entry_point()),
+            shader_set(
+                ShaderModule::entry_point(&vertex),
+                ShaderModule::entry_point(&fragment),
+            ),
             Primitive::TriangleList,
             FILL_RASTERIZER,
             &layout,
@@ -171,7 +176,7 @@ impl Graphics {
                 },
             )),
         );
-        let desc_sets = vec![desc_pool.allocate_set(set_layout.as_ref()).unwrap()];
+        let desc_sets = vec![desc_pool.allocate_set(&*set_layout).unwrap()];
 
         Self {
             desc_pool,
@@ -202,11 +207,14 @@ impl Graphics {
         );
         let layout = PipelineLayout::new(
             Driver::clone(&driver),
-            once(set_layout.as_ref()),
+            once(&*set_layout),
             &[(ShaderStageFlags::VERTEX, 0..64)],
         );
         let mut desc = GraphicsPipelineDesc::new(
-            shader_set(vertex.entry_point(), fragment.entry_point()),
+            shader_set(
+                ShaderModule::entry_point(&vertex),
+                ShaderModule::entry_point(&fragment),
+            ),
             Primitive::LineList,
             LINE_RASTERIZER,
             &layout,
@@ -288,14 +296,17 @@ impl Graphics {
         );
         let layout = PipelineLayout::new(
             Driver::clone(&driver),
-            once(set_layout.as_ref()),
+            once(&*set_layout),
             &[
                 (ShaderStageFlags::VERTEX, 0..100),
                 (ShaderStageFlags::FRAGMENT, 100..104),
             ],
         );
         let mut desc = GraphicsPipelineDesc::new(
-            shader_set(vertex.entry_point(), fragment.entry_point()),
+            shader_set(
+                ShaderModule::entry_point(&vertex),
+                ShaderModule::entry_point(&fragment),
+            ),
             Primitive::TriangleList,
             FILL_RASTERIZER,
             &layout,
@@ -353,7 +364,7 @@ impl Graphics {
                 },
             )),
         );
-        let desc_sets = vec![desc_pool.allocate_set(set_layout.as_ref()).unwrap()];
+        let desc_sets = vec![desc_pool.allocate_set(&*set_layout).unwrap()];
 
         Self {
             desc_pool,
@@ -391,14 +402,17 @@ impl Graphics {
         );
         let layout = PipelineLayout::new(
             Driver::clone(&driver),
-            once(set_layout.as_ref()),
+            once(&*set_layout),
             &[
                 (ShaderStageFlags::VERTEX, 0..100),
                 (ShaderStageFlags::FRAGMENT, 100..104),
             ],
         );
         let mut desc = GraphicsPipelineDesc::new(
-            shader_set(vertex.entry_point(), fragment.entry_point()),
+            shader_set(
+                ShaderModule::entry_point(&vertex),
+                ShaderModule::entry_point(&fragment),
+            ),
             Primitive::TriangleList,
             FILL_RASTERIZER,
             &layout,
@@ -456,7 +470,7 @@ impl Graphics {
                 },
             )),
         );
-        let desc_sets = vec![desc_pool.allocate_set(set_layout.as_ref()).unwrap()];
+        let desc_sets = vec![desc_pool.allocate_set(&*set_layout).unwrap()];
 
         Self {
             desc_pool,
@@ -494,11 +508,14 @@ impl Graphics {
         );
         let layout = PipelineLayout::new(
             Driver::clone(&driver),
-            once(set_layout.as_ref()),
+            once(&*set_layout),
             &[(ShaderStageFlags::VERTEX, 0..64)],
         );
         let mut desc = GraphicsPipelineDesc::new(
-            shader_set(vertex.entry_point(), fragment.entry_point()),
+            shader_set(
+                ShaderModule::entry_point(&vertex),
+                ShaderModule::entry_point(&fragment),
+            ),
             Primitive::TriangleList,
             FILL_RASTERIZER,
             &layout,
@@ -525,7 +542,7 @@ impl Graphics {
                 },
             )),
         );
-        let desc_sets = vec![desc_pool.allocate_set(set_layout.as_ref()).unwrap()];
+        let desc_sets = vec![desc_pool.allocate_set(&*set_layout).unwrap()];
 
         Self {
             desc_pool,
@@ -563,11 +580,14 @@ impl Graphics {
         );
         let layout = PipelineLayout::new(
             Driver::clone(&driver),
-            once(set_layout.as_ref()),
+            once(&*set_layout),
             &[(ShaderStageFlags::VERTEX, 0..64)],
         );
         let mut desc = GraphicsPipelineDesc::new(
-            shader_set(vertex.entry_point(), fragment.entry_point()),
+            shader_set(
+                ShaderModule::entry_point(&vertex),
+                ShaderModule::entry_point(&fragment),
+            ),
             Primitive::TriangleList,
             FILL_RASTERIZER,
             &layout,
@@ -617,7 +637,7 @@ impl Graphics {
                 },
             )),
         );
-        let desc_sets = vec![desc_pool.allocate_set(set_layout.as_ref()).unwrap()];
+        let desc_sets = vec![desc_pool.allocate_set(&*set_layout).unwrap()];
 
         Self {
             desc_pool,
@@ -667,14 +687,17 @@ impl Graphics {
         );
         let layout = PipelineLayout::new(
             Driver::clone(&driver),
-            once(set_layout.as_ref()),
+            once(&*set_layout),
             &[
                 (ShaderStageFlags::VERTEX, 0..100),
                 (ShaderStageFlags::FRAGMENT, 100..104),
             ],
         );
         let mut desc = GraphicsPipelineDesc::new(
-            shader_set(vertex.entry_point(), fragment.entry_point()),
+            shader_set(
+                ShaderModule::entry_point(&vertex),
+                ShaderModule::entry_point(&fragment),
+            ),
             Primitive::TriangleList,
             FILL_RASTERIZER,
             &layout,
@@ -730,7 +753,7 @@ impl Graphics {
                 },
             )),
         );
-        let desc_sets = vec![desc_pool.allocate_set(set_layout.as_ref()).unwrap()];
+        let desc_sets = vec![desc_pool.allocate_set(&*set_layout).unwrap()];
 
         Self {
             desc_pool,
@@ -768,14 +791,17 @@ impl Graphics {
         );
         let layout = PipelineLayout::new(
             Driver::clone(&driver),
-            once(set_layout.as_ref()),
+            once(&*set_layout),
             &[
                 (ShaderStageFlags::VERTEX, 0..64),
                 (ShaderStageFlags::FRAGMENT, 64..80),
             ],
         );
         let mut desc = GraphicsPipelineDesc::new(
-            shader_set(vertex.entry_point(), fragment.entry_point()),
+            shader_set(
+                ShaderModule::entry_point(&vertex),
+                ShaderModule::entry_point(&fragment),
+            ),
             Primitive::TriangleList,
             FILL_RASTERIZER,
             &layout,
@@ -823,7 +849,7 @@ impl Graphics {
                 },
             )),
         );
-        let desc_sets = vec![desc_pool.allocate_set(set_layout.as_ref()).unwrap()];
+        let desc_sets = vec![desc_pool.allocate_set(&*set_layout).unwrap()];
 
         Self {
             desc_pool,
@@ -859,14 +885,17 @@ impl Graphics {
         );
         let layout = PipelineLayout::new(
             Driver::clone(&driver),
-            once(set_layout.as_ref()),
+            once(&*set_layout),
             &[
                 (ShaderStageFlags::VERTEX, 0..64),
                 (ShaderStageFlags::FRAGMENT, 64..96),
             ],
         );
         let mut desc = GraphicsPipelineDesc::new(
-            shader_set(vertex.entry_point(), fragment.entry_point()),
+            shader_set(
+                ShaderModule::entry_point(&vertex),
+                ShaderModule::entry_point(&fragment),
+            ),
             Primitive::TriangleList,
             FILL_RASTERIZER,
             &layout,
@@ -914,7 +943,7 @@ impl Graphics {
                 },
             )),
         );
-        let desc_sets = vec![desc_pool.allocate_set(set_layout.as_ref()).unwrap()];
+        let desc_sets = vec![desc_pool.allocate_set(&*set_layout).unwrap()];
 
         Self {
             desc_pool,
@@ -950,11 +979,14 @@ impl Graphics {
         );
         let layout = PipelineLayout::new(
             Driver::clone(&driver),
-            once(set_layout.as_ref()),
+            once(&*set_layout),
             &[(ShaderStageFlags::FRAGMENT, 0..32)],
         );
         let mut desc = GraphicsPipelineDesc::new(
-            shader_set(vertex.entry_point(), fragment.entry_point()),
+            shader_set(
+                ShaderModule::entry_point(&vertex),
+                ShaderModule::entry_point(&fragment),
+            ),
             Primitive::TriangleList,
             FILL_RASTERIZER,
             &layout,
@@ -981,7 +1013,7 @@ impl Graphics {
                 },
             )),
         );
-        let desc_sets = vec![desc_pool.allocate_set(set_layout.as_ref()).unwrap()];
+        let desc_sets = vec![desc_pool.allocate_set(&*set_layout).unwrap()];
 
         Self {
             desc_pool,
@@ -1017,11 +1049,14 @@ impl Graphics {
         );
         let layout = PipelineLayout::new(
             Driver::clone(&driver),
-            once(set_layout.as_ref()),
+            once(&*set_layout),
             &[(ShaderStageFlags::FRAGMENT, 0..32)],
         );
         let mut desc = GraphicsPipelineDesc::new(
-            shader_set(vertex.entry_point(), fragment.entry_point()),
+            shader_set(
+                ShaderModule::entry_point(&vertex),
+                ShaderModule::entry_point(&fragment),
+            ),
             Primitive::TriangleList,
             FILL_RASTERIZER,
             &layout,
@@ -1048,7 +1083,7 @@ impl Graphics {
                 },
             )),
         );
-        let desc_sets = vec![desc_pool.allocate_set(set_layout.as_ref()).unwrap()];
+        let desc_sets = vec![desc_pool.allocate_set(&*set_layout).unwrap()];
 
         Self {
             desc_pool,
@@ -1084,11 +1119,14 @@ impl Graphics {
         );
         let layout = PipelineLayout::new(
             Driver::clone(&driver),
-            once(set_layout.as_ref()),
+            once(&*set_layout),
             &[(ShaderStageFlags::VERTEX, 0..64)],
         );
         let mut desc = GraphicsPipelineDesc::new(
-            shader_set(vertex.entry_point(), fragment.entry_point()),
+            shader_set(
+                ShaderModule::entry_point(&vertex),
+                ShaderModule::entry_point(&fragment),
+            ),
             Primitive::TriangleList,
             FILL_RASTERIZER,
             &layout,
@@ -1115,7 +1153,7 @@ impl Graphics {
                 },
             )),
         );
-        let desc_sets = vec![desc_pool.allocate_set(set_layout.as_ref()).unwrap()];
+        let desc_sets = vec![desc_pool.allocate_set(&*set_layout).unwrap()];
 
         Self {
             desc_pool,
@@ -1150,11 +1188,7 @@ impl Graphics {
         }
 
         for desc_set in &mut self.desc_sets {
-            *desc_set = unsafe {
-                self.desc_pool
-                    .allocate_set(self.set_layout.as_ref())
-                    .unwrap()
-            }
+            *desc_set = unsafe { self.desc_pool.allocate_set(&*self.set_layout).unwrap() }
         }
     }
 

--- a/src/gpu/pool/lease.rs
+++ b/src/gpu/pool/lease.rs
@@ -3,6 +3,8 @@ use {
     std::ops::{Deref, DerefMut},
 };
 
+/// A smart pointer type which automatically returns the associated resource to
+/// the pool when dropped.
 #[derive(Debug)]
 pub struct Lease<T> {
     item: Option<T>,
@@ -15,18 +17,6 @@ impl<T> Lease<T> {
             item: Some(item),
             pool: PoolRef::clone(pool),
         }
-    }
-}
-
-impl<T> AsMut<T> for Lease<T> {
-    fn as_mut(&mut self) -> &mut T {
-        self
-    }
-}
-
-impl<T> AsRef<T> for Lease<T> {
-    fn as_ref(&self) -> &T {
-        self
     }
 }
 

--- a/src/gpu/texture.rs
+++ b/src/gpu/texture.rs
@@ -5,7 +5,6 @@ use {
     },
     gfx_hal::{
         command::CommandBuffer,
-        device::Device,
         format::{Aspects, Format, Swizzle},
         image::{Access, Layout, SubresourceRange, Tiling, Usage, ViewKind},
         memory::{Barrier, Dependencies},
@@ -21,6 +20,9 @@ use {
 };
 
 pub(crate) struct Image(<_Backend as Backend>::Image);
+
+#[cfg(debug_assertions)]
+use gfx_hal::device::Device as _;
 
 impl AsRef<<_Backend as Backend>::Image> for Image {
     fn as_ref(&self) -> &<_Backend as Backend>::Image {
@@ -211,11 +213,11 @@ impl Texture<Image2d> {
         let format = {
             let device = driver.as_ref().borrow();
             device
-                .get_best_format(desired_format, desired_tiling, usage)
+                .best_fmt(desired_format, desired_tiling, usage)
                 .unwrap_or_else(|| {
                     desired_tiling = Tiling::Linear;
                     device
-                        .get_best_format(desired_format, desired_tiling, usage)
+                        .best_fmt(desired_format, desired_tiling, usage)
                         .unwrap()
                 })
         };
@@ -283,12 +285,6 @@ where
 pub struct ImageViewRef<'a> {
     key: ImageViewKey,
     views: Ref<'a, HashMap<ImageViewKey, ImageView>>,
-}
-
-impl<'a> AsRef<<_Backend as Backend>::ImageView> for ImageViewRef<'a> {
-    fn as_ref(&self) -> &<_Backend as Backend>::ImageView {
-        &self.views[&self.key]
-    }
 }
 
 impl<'a> Deref for ImageViewRef<'a> {

--- a/src/input/key_buf.rs
+++ b/src/input/key_buf.rs
@@ -1,13 +1,11 @@
-use winit::event::KeyboardInput;
-
-use super::KeyCode;
+use {super::Key, winit::event::KeyboardInput};
 
 const DEFAULT_EVENT_CAPACITY: usize = 16;
 
 pub struct KeyBuf {
     char_buf: String,
-    pressed_keys: Vec<KeyCode>,
-    released_keys: Vec<KeyCode>,
+    pressed_keys: Vec<Key>,
+    released_keys: Vec<Key>,
 }
 
 impl KeyBuf {
@@ -45,11 +43,11 @@ impl KeyBuf {
         }
     }*/
 
-    pub fn is_key_down(&self, key_code: KeyCode) -> bool {
+    pub fn is_key_down(&self, key_code: Key) -> bool {
         self.pressed_keys.contains(&key_code)
     }
 
-    pub fn was_key_down(&self, key_code: KeyCode) -> bool {
+    pub fn was_key_down(&self, key_code: Key) -> bool {
         self.released_keys.contains(&key_code)
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,8 +1,8 @@
-mod key;
-mod mouse;
+mod key_buf;
+mod mouse_buf;
 mod typing;
 
-pub use self::{key::KeyBuf, mouse::MouseBuf, typing::Typing};
+pub use self::{key_buf::KeyBuf, mouse_buf::MouseBuf, typing::Typing};
 
 #[derive(Default)]
 pub struct Input {
@@ -10,8 +10,9 @@ pub struct Input {
     pub mouse: MouseBuf,
 }
 
+// TODO: Should we add 'normal' keys as something like `Other(char)`?
 #[derive(PartialEq)]
-pub enum KeyCode {
+pub enum Key {
     Back,
     Left,
     Delete,

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -1,2 +1,0 @@
-#[derive(Default)]
-pub struct MouseBuf {}

--- a/src/input/mouse_buf.rs
+++ b/src/input/mouse_buf.rs
@@ -1,0 +1,13 @@
+use crate::math::Coord;
+
+#[derive(Default)]
+pub struct MouseBuf {}
+
+impl MouseBuf {
+    /// Returns the mouse position relative to the center of the screen in pixel coordinates. When
+    /// at rest the mouse position will be (0,0) and moving to the left or up will produce negative values.
+    /// The mouse position is reset to (0,0) before each engine update.
+    pub fn pos(&self) -> Coord {
+        todo!()
+    }
+}

--- a/src/input/typing.rs
+++ b/src/input/typing.rs
@@ -1,4 +1,4 @@
-use super::{KeyBuf, KeyCode};
+use super::{Key, KeyBuf};
 
 #[derive(Default, PartialEq)]
 pub struct Typing {
@@ -29,7 +29,7 @@ impl Typing {
         }
 
         // Handle back/forward delete and cursor movement
-        if input.is_key_down(KeyCode::Back) && 0 < self.pos {
+        if input.is_key_down(Key::Back) && 0 < self.pos {
             if self.pos == self.buf.len() {
                 if let Some(c) = self.buf.pop() {
                     self.pos -= c.len_utf8();
@@ -44,25 +44,25 @@ impl Typing {
                 self.buf.push_str(&lhs);
                 self.buf.push_str(&rhs);
             }
-        } else if input.is_key_down(KeyCode::Delete) && self.pos < self.buf.len() {
+        } else if input.is_key_down(Key::Delete) && self.pos < self.buf.len() {
             let (_, rhs) = self.to_split_string();
             let mut rhs = rhs.chars();
             rhs.next();
             self.buf.truncate(self.pos);
             self.buf.push_str(rhs.as_str());
-        } else if input.is_key_down(KeyCode::Left) && 0 < self.pos {
+        } else if input.is_key_down(Key::Left) && 0 < self.pos {
             let (lhs, _) = self.buf.split_at(self.pos);
             if let Some(c) = lhs.chars().last() {
                 self.pos -= c.len_utf8();
             }
-        } else if input.is_key_down(KeyCode::Right) && self.pos < self.buf.len() {
+        } else if input.is_key_down(Key::Right) && self.pos < self.buf.len() {
             let (_, rhs) = self.buf.split_at(self.pos);
             if let Some(c) = rhs.chars().next() {
                 self.pos += c.len_utf8();
             }
-        } else if input.is_key_down(KeyCode::Home) {
+        } else if input.is_key_down(Key::Home) {
             self.pos = 0;
-        } else if input.is_key_down(KeyCode::End) {
+        } else if input.is_key_down(Key::End) {
             self.pos = self.buf.len();
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,8 @@
 #![deny(warnings)]
-// TODO: Remove before flight!
 #![allow(dead_code)]
-#![allow(unused_assignments)]
-//#![allow(unused_imports)]
-#![allow(unused_mut)]
-#![allow(unused_variables)]
 
-#[cfg(debug_assertions)]
 extern crate pretty_env_logger;
 
-#[cfg(debug_assertions)]
 #[macro_use]
 extern crate log as log_crate;
 
@@ -68,7 +61,6 @@ pub type DynScreen = Box<dyn Screen>;
 
 /// Only required when you are not running an engine instance but still using other
 /// engine types and you want debugging setup.
-#[cfg(debug_assertions)]
 pub fn init_debug() {
     pretty_env_logger::init();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,4 @@
 #![deny(warnings)]
-// TODO: Remove before flight!
-#![allow(unused_imports)]
-#![allow(unused_mut)]
-#![allow(unused_unsafe)]
-#![allow(unused_variables)]
 #![allow(dead_code)]
 
 #[macro_use]
@@ -16,18 +11,17 @@ mod pak;
 use {
     self::{
         bake::{
-            bake_bitmap, bake_blob, bake_font_bitmap, bake_lang, bake_mesh, bake_scene, bake_text,
-            Asset, PakLog,
+            bake_atlas, bake_bitmap, bake_blob, bake_font_bitmap, bake_lang, bake_mesh, bake_scene,
+            bake_text, Asset, PakLog,
         },
         pak::PakBuf,
     },
-    glob::glob,
     pretty_env_logger::init,
     std::{
         env::{args, current_dir, current_exe},
         fs::{create_dir_all, File},
         io::{BufRead, BufReader, BufWriter, Error as IoError},
-        path::{Path, PathBuf},
+        path::PathBuf,
     },
 };
 
@@ -109,10 +103,13 @@ fn main() -> Result<(), IoError> {
 
         let mut assets = vec![line];
         while let Some(asset) = assets.pop() {
-            let mut asset_filename = project_dir.join(PathBuf::from(&asset));
+            let asset_filename = project_dir.join(PathBuf::from(&asset));
 
             match bake {
                 Bake::Asset => match Asset::read(&asset_filename) {
+                    Asset::Atlas(ref atlas) => {
+                        bake_atlas(&project_dir, &asset_filename, atlas, &mut pak, &mut log);
+                    }
                     Asset::Bitmap(ref bitmap) => {
                         bake_bitmap(&project_dir, &asset_filename, bitmap, &mut pak, &mut log);
                     }
@@ -126,7 +123,7 @@ fn main() -> Result<(), IoError> {
                         bake_mesh(&project_dir, &asset_filename, mesh, &mut pak, &mut log);
                     }
                     Asset::Scene(scene) => {
-                        for key in bake_scene(&project_dir, &asset_filename, &scene, &mut pak) {
+                        for _key in bake_scene(&project_dir, &asset_filename, &scene, &mut pak) {
                             //lines.push(key);
                         }
                     }

--- a/src/math/coord.rs
+++ b/src/math/coord.rs
@@ -1,9 +1,14 @@
 use {
-    gfx_hal::{image::Extent, pso::Rect, window::Extent2D},
+    gfx_hal::{
+        image::{Extent, Offset},
+        pso::Rect,
+        window::Extent2D,
+    },
+    serde::{Deserialize, Serialize},
     winit::dpi::PhysicalSize,
 };
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Coord<T>
 where
     T: Sized,
@@ -22,12 +27,12 @@ where
 }
 
 impl Coord<i32> {
-    pub const fn zero() -> Self {
-        Self { x: 0, y: 0 }
-    }
+    pub const ZERO: Self = Self { x: 0, y: 0 };
 }
 
 impl Coord<u32> {
+    pub const ZERO: Self = Self { x: 0, y: 0 };
+
     pub const fn as_extent(self, depth: u32) -> Extent {
         Extent {
             width: self.x,
@@ -36,21 +41,21 @@ impl Coord<u32> {
         }
     }
 
-    pub const fn as_rect(self) -> Rect {
-        self.as_rect_xy(Self::zero())
-    }
-
-    pub const fn as_rect_xy(self, xy: Self) -> Rect {
-        Rect {
-            x: xy.x as _,
-            y: xy.y as _,
-            w: self.x as _,
-            h: self.y as _,
+    pub const fn as_offset(self, z: i32) -> Offset {
+        Offset {
+            x: self.x as _,
+            y: self.y as _,
+            z,
         }
     }
 
-    pub const fn zero() -> Self {
-        Self { x: 0, y: 0 }
+    pub const fn as_rect(self, pos: Self) -> Rect {
+        Rect {
+            x: pos.x as _,
+            y: pos.y as _,
+            w: self.x as _,
+            h: self.y as _,
+        }
     }
 }
 
@@ -59,6 +64,15 @@ impl From<PhysicalSize<u32>> for Coord<u32> {
         Self {
             x: val.width,
             y: val.height,
+        }
+    }
+}
+
+impl From<Coord<i32>> for Coord<f32> {
+    fn from(val: Coord<i32>) -> Self {
+        Self {
+            x: val.x as _,
+            y: val.y as _,
         }
     }
 }
@@ -86,6 +100,17 @@ impl From<Coord<u32>> for PhysicalSize<u32> {
         Self {
             height: val.y,
             width: val.x,
+        }
+    }
+}
+
+impl From<Coord<u32>> for Rect {
+    fn from(val: Coord<u32>) -> Self {
+        Self {
+            h: val.y as _,
+            w: val.x as _,
+            x: 0,
+            y: 0,
         }
     }
 }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -5,10 +5,11 @@ pub use glam::{mat4, quat, vec2, vec3, vec4, Mat3, Mat4, Quat, Vec2, Vec3, Vec4}
 
 use self::{coord::Coord as GenericCoord, rect::Rect as GenericRect};
 
+pub type Area = GenericRect<u32, u32>;
 pub type Coord = GenericCoord<i32>;
 pub type CoordF = GenericCoord<f32>;
 pub type Extent = GenericCoord<u32>;
-pub type Rect = GenericRect<i32, u32>;
+pub type Rect = GenericRect<u32, i32>;
 pub type RectF = GenericRect<f32, f32>;
 
 pub fn vec4_from_vec3(vec: Vec3, w: f32) -> Vec4 {

--- a/src/math/rect.rs
+++ b/src/math/rect.rs
@@ -1,10 +1,13 @@
-use super::GenericCoord;
+use {
+    super::GenericCoord,
+    serde::{Deserialize, Serialize},
+};
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Rect<D, P>
 where
-    D: Copy,
-    P: Copy,
+    D: Sized,
+    P: Sized,
 {
     pub dims: GenericCoord<D>,
     pub pos: GenericCoord<P>,
@@ -12,8 +15,8 @@ where
 
 impl<D, P> Rect<D, P>
 where
-    D: Copy,
-    P: Copy,
+    D: Sized,
+    P: Sized,
 {
     pub fn new(x: P, y: P, width: D, height: D) -> Self {
         Self {
@@ -22,6 +25,33 @@ where
                 y: height,
             },
             pos: GenericCoord { x, y },
+        }
+    }
+}
+
+impl From<GenericCoord<u32>> for Rect<u32, u32> {
+    fn from(val: GenericCoord<u32>) -> Self {
+        Self {
+            dims: val,
+            pos: GenericCoord::<u32>::ZERO,
+        }
+    }
+}
+
+impl From<GenericCoord<u32>> for Rect<u32, i32> {
+    fn from(val: GenericCoord<u32>) -> Self {
+        Self {
+            dims: val,
+            pos: GenericCoord::<i32>::ZERO,
+        }
+    }
+}
+
+impl From<Rect<u32, i32>> for Rect<f32, f32> {
+    fn from(val: Rect<u32, i32>) -> Self {
+        Self {
+            dims: val.dims.into(),
+            pos: val.pos.into(),
         }
     }
 }

--- a/src/pak/data_ref.rs
+++ b/src/pak/data_ref.rs
@@ -11,20 +11,14 @@ impl<T> DataRef<T> {
     pub fn as_data(&self) -> &T {
         match self {
             Self::Data(ref t) => t,
-            _ => panic!(
-                #[cfg(debug_assertions)]
-                "This DataRef is a ref when it should be data"
-            ),
+            _ => panic!("This DataRef is a ref when it should be data"),
         }
     }
 
     pub fn as_ref(&self) -> (u64, usize) {
         match self {
             Self::Ref((pos, len)) => (*pos as _, *len as _),
-            _ => panic!(
-                #[cfg(debug_assertions)]
-                "This DataRef is data when it should be a ref"
-            ),
+            _ => panic!("This DataRef is data when it should be a ref"),
         }
     }
 

--- a/src/pak/pak_buf.rs
+++ b/src/pak/pak_buf.rs
@@ -48,12 +48,7 @@ impl PakBuf {
     fn id<K: AsRef<str>>(&self, key: K) -> Id {
         self.ids
             .get(key.as_ref())
-            .unwrap_or_else(|| {
-                panic!(
-                    #[cfg(debug_assertions)]
-                    format!("Key `{}` not found", key.as_ref())
-                )
-            })
+            .unwrap_or_else(|| panic!(format!("Key `{}` not found", key.as_ref())))
             .clone()
     }
 


### PR DESCRIPTION
Lots of unrelated changes that all drive the library forward:
- Atlas feature started
- Draw (lines, meshes) improved, still needs lots of work
- Write (bitmaps) now supports a list of writes that all get drawn in one batch
- Nibbles example code completed, but not tested as drawing lines is still not working
- Gorilla example started and some art added
- Improved many of the internal patterns with GFX-HAL usage: push constants, descriptors, `Op`-code readability and comments
- GPU Driver code bent closer to Rust API guidelines
- Documentation and Readme improvements