### PR TITLE
Fix: fix swapchain not updating its image extents upon recreation/resize

### DIFF
--- a/src/driver/swapchain.rs
+++ b/src/driver/swapchain.rs
@@ -320,8 +320,8 @@ where
                         flags: vk::ImageCreateFlags::empty(), // MUTABLE_FORMAT | SPARSE_ALIASED | CUBE_COMPATIBLE
                         fmt: vk::Format::B8G8R8A8_UNORM,      // TODO: Allow configuration!
                         depth: 0,                             // TODO: 1?
-                        height: self.info.height,
-                        width: self.info.width,
+                        height: surface_height,
+                        width: surface_width,
                         sample_count: SampleCount::X1,
                         linear_tiling: false,
                         mip_level_count: 1,
@@ -335,6 +335,8 @@ where
 
         assert_eq!(desired_image_count, images.len() as u32);
 
+        self.info.height = surface_height;
+        self.info.width = surface_width;
         self.next_semaphore = 0;
         self.images = images;
         self.swapchain = swapchain;


### PR DESCRIPTION
Fixes swapchain recreation not updating its own info's bounds, this caused `present2` to launch with an invalid invocation size, which made any resized areas black. Resizing seems to work fine now, however, old resources leftover from resizing will not be dropped, this is not ideal because it is leaking memory. My thought for resolving this is doing something similar to what granite does, making image size an enum of either "swapchain-relative" or "absolute" then doing the culling... somewhere.