### PR TITLE
Bindless support

### DIFF
--- a/src/driver/compute.rs
+++ b/src/driver/compute.rs
@@ -41,7 +41,13 @@ where
         let shader = info.clone().into_shader();
 
         // Use SPIR-V reflection to get the types and counts of all descriptors
-        let descriptor_bindings = shader.descriptor_bindings(&device);
+        let mut descriptor_bindings = shader.descriptor_bindings(&device);
+        for (descriptor_info, _) in descriptor_bindings.values_mut() {
+            if descriptor_info.binding_count() == 0 {
+                descriptor_info.set_binding_count(info.bindless_descriptor_count);
+            }
+        }
+
         let descriptor_info = PipelineDescriptorInfo::create(&device, &descriptor_bindings)?;
         let descriptor_set_layouts = descriptor_info
             .layouts
@@ -153,6 +159,9 @@ where
 #[derive(Builder, Clone, Debug)]
 #[builder(pattern = "owned")]
 pub struct ComputePipelineInfo {
+    #[builder(default = "8192")]
+    pub bindless_descriptor_count: u32,
+
     /// The GLSL or HLSL shader entry point name, or `main` by default.
     #[builder(setter(strip_option), default = "String::from(\"main\")")]
     pub entry_name: String,

--- a/src/driver/device.rs
+++ b/src/driver/device.rs
@@ -148,6 +148,8 @@ where
             vk::PhysicalDeviceImagelessFramebufferFeatures::builder();
         let mut buffer_device_address_features =
             vk::PhysicalDeviceBufferDeviceAddressFeatures::builder();
+        let mut descriptor_indexing_features =
+            vk::PhysicalDeviceDescriptorIndexingFeatures::builder();
 
         #[cfg(not(target_os = "macos"))]
         let mut separate_depth_stencil_layouts_features =
@@ -168,6 +170,7 @@ where
         unsafe {
             let mut features2 = vk::PhysicalDeviceFeatures2::builder()
                 .push_next(&mut buffer_device_address_features)
+                .push_next(&mut descriptor_indexing_features)
                 .push_next(&mut imageless_framebuffer_features);
 
             #[cfg(not(target_os = "macos"))]

--- a/src/driver/device.rs
+++ b/src/driver/device.rs
@@ -1,7 +1,8 @@
 use {
     super::{
         DriverConfig, DriverError, Instance, PhysicalDevice,
-        PhysicalDeviceRayTracePipelineProperties, QueueFamily, SamplerDesc, Surface,
+        PhysicalDeviceDescriptorIndexingFeatures, PhysicalDeviceRayTracePipelineProperties,
+        QueueFamily, SamplerDesc, Surface,
     },
     archery::{SharedPointer, SharedPointerKind},
     ash::{extensions::khr, vk},
@@ -30,6 +31,7 @@ where
 {
     pub accel_struct_ext: Option<khr::AccelerationStructure>,
     pub(super) allocator: Option<Mutex<Allocator>>,
+    pub descriptor_indexing_features: PhysicalDeviceDescriptorIndexingFeatures,
     device: ash::Device,
     immutable_samplers: HashMap<SamplerDesc, vk::Sampler>,
     pub instance: SharedPointer<Instance, P>, // TODO: Need shared?
@@ -358,9 +360,12 @@ where
                 (None, None)
             };
 
+            let descriptor_indexing_features = descriptor_indexing_features.build().into();
+
             Ok(Self {
                 accel_struct_ext,
                 allocator: Some(Mutex::new(allocator)),
+                descriptor_indexing_features,
                 device,
                 immutable_samplers,
                 instance,

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -562,6 +562,95 @@ impl Display for DriverError {
 
 impl Error for DriverError {}
 
+pub struct PhysicalDeviceDescriptorIndexingFeatures {
+    pub shader_input_attachment_array_dynamic_indexing: bool,
+    pub shader_uniform_texel_buffer_array_dynamic_indexing: bool,
+    pub shader_storage_texel_buffer_array_dynamic_indexing: bool,
+    pub shader_uniform_buffer_array_non_uniform_indexing: bool,
+    pub shader_sampled_image_array_non_uniform_indexing: bool,
+    pub shader_storage_buffer_array_non_uniform_indexing: bool,
+    pub shader_storage_image_array_non_uniform_indexing: bool,
+    pub shader_input_attachment_array_non_uniform_indexing: bool,
+    pub shader_uniform_texel_buffer_array_non_uniform_indexing: bool,
+    pub shader_storage_texel_buffer_array_non_uniform_indexing: bool,
+    pub descriptor_binding_uniform_buffer_update_after_bind: bool,
+    pub descriptor_binding_sampled_image_update_after_bind: bool,
+    pub descriptor_binding_storage_image_update_after_bind: bool,
+    pub descriptor_binding_storage_buffer_update_after_bind: bool,
+    pub descriptor_binding_uniform_texel_buffer_update_after_bind: bool,
+    pub descriptor_binding_storage_texel_buffer_update_after_bind: bool,
+    pub descriptor_binding_update_unused_while_pending: bool,
+    pub descriptor_binding_partially_bound: bool,
+    pub descriptor_binding_variable_descriptor_count: bool,
+    pub runtime_descriptor_array: bool,
+}
+
+impl From<vk::PhysicalDeviceDescriptorIndexingFeatures>
+    for PhysicalDeviceDescriptorIndexingFeatures
+{
+    fn from(features: vk::PhysicalDeviceDescriptorIndexingFeatures) -> Self {
+        Self {
+            shader_input_attachment_array_dynamic_indexing: features
+                .shader_input_attachment_array_dynamic_indexing
+                == vk::TRUE,
+            shader_uniform_texel_buffer_array_dynamic_indexing: features
+                .shader_uniform_texel_buffer_array_dynamic_indexing
+                == vk::TRUE,
+            shader_storage_texel_buffer_array_dynamic_indexing: features
+                .shader_storage_texel_buffer_array_dynamic_indexing
+                == vk::TRUE,
+            shader_uniform_buffer_array_non_uniform_indexing: features
+                .shader_uniform_buffer_array_non_uniform_indexing
+                == vk::TRUE,
+            shader_sampled_image_array_non_uniform_indexing: features
+                .shader_sampled_image_array_non_uniform_indexing
+                == vk::TRUE,
+            shader_storage_buffer_array_non_uniform_indexing: features
+                .shader_storage_buffer_array_non_uniform_indexing
+                == vk::TRUE,
+            shader_storage_image_array_non_uniform_indexing: features
+                .shader_storage_image_array_non_uniform_indexing
+                == vk::TRUE,
+            shader_input_attachment_array_non_uniform_indexing: features
+                .shader_input_attachment_array_non_uniform_indexing
+                == vk::TRUE,
+            shader_uniform_texel_buffer_array_non_uniform_indexing: features
+                .shader_uniform_texel_buffer_array_non_uniform_indexing
+                == vk::TRUE,
+            shader_storage_texel_buffer_array_non_uniform_indexing: features
+                .shader_storage_texel_buffer_array_non_uniform_indexing
+                == vk::TRUE,
+            descriptor_binding_uniform_buffer_update_after_bind: features
+                .descriptor_binding_uniform_buffer_update_after_bind
+                == vk::TRUE,
+            descriptor_binding_sampled_image_update_after_bind: features
+                .descriptor_binding_sampled_image_update_after_bind
+                == vk::TRUE,
+            descriptor_binding_storage_image_update_after_bind: features
+                .descriptor_binding_storage_image_update_after_bind
+                == vk::TRUE,
+            descriptor_binding_storage_buffer_update_after_bind: features
+                .descriptor_binding_storage_buffer_update_after_bind
+                == vk::TRUE,
+            descriptor_binding_uniform_texel_buffer_update_after_bind: features
+                .descriptor_binding_uniform_texel_buffer_update_after_bind
+                == vk::TRUE,
+            descriptor_binding_storage_texel_buffer_update_after_bind: features
+                .descriptor_binding_storage_texel_buffer_update_after_bind
+                == vk::TRUE,
+            descriptor_binding_update_unused_while_pending: features
+                .descriptor_binding_update_unused_while_pending
+                == vk::TRUE,
+            descriptor_binding_partially_bound: features.descriptor_binding_partially_bound
+                == vk::TRUE,
+            descriptor_binding_variable_descriptor_count: features
+                .descriptor_binding_variable_descriptor_count
+                == vk::TRUE,
+            runtime_descriptor_array: features.runtime_descriptor_array == vk::TRUE,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct PhysicalDeviceRayTracePipelineProperties {
     pub shader_group_handle_size: u32,

--- a/src/driver/ray_trace.rs
+++ b/src/driver/ray_trace.rs
@@ -46,11 +46,16 @@ where
             .collect::<Vec<Shader>>();
 
         // Use SPIR-V reflection to get the types and counts of all descriptors
-        let descriptor_bindings = Shader::merge_descriptor_bindings(
+        let mut descriptor_bindings = Shader::merge_descriptor_bindings(
             shaders
                 .iter()
                 .map(|shader| shader.descriptor_bindings(device)),
         );
+        for (descriptor_info, _) in descriptor_bindings.values_mut() {
+            if descriptor_info.binding_count() == 0 {
+                descriptor_info.set_binding_count(info.bindless_descriptor_count);
+            }
+        }
 
         let descriptor_info = PipelineDescriptorInfo::create(device, &descriptor_bindings)?;
         let descriptor_set_layout_handles = descriptor_info
@@ -215,6 +220,9 @@ where
     pattern = "owned"
 )]
 pub struct RayTracePipelineInfo {
+    #[builder(default = "8192")]
+    pub bindless_descriptor_count: u32,
+
     #[builder(default = "16")]
     pub max_ray_recursion_depth: u32,
 

--- a/src/driver/shader.rs
+++ b/src/driver/shader.rs
@@ -113,6 +113,23 @@ impl DescriptorInfo {
             _ => None,
         }
     }
+
+    pub fn set_binding_count(&mut self, binding_count: u32) {
+        *match self {
+            Self::AccelerationStructure(binding_count) => binding_count,
+            Self::CombinedImageSampler(binding_count, _) => binding_count,
+            Self::InputAttachment(binding_count, _) => binding_count,
+            Self::SampledImage(binding_count) => binding_count,
+            Self::Sampler(binding_count) => binding_count,
+            Self::StorageBuffer(binding_count) => binding_count,
+            Self::StorageBufferDynamic(binding_count) => binding_count,
+            Self::StorageImage(binding_count) => binding_count,
+            Self::StorageTexelBuffer(binding_count) => binding_count,
+            Self::UniformBuffer(binding_count) => binding_count,
+            Self::UniformBufferDynamic(binding_count) => binding_count,
+            Self::UniformTexelBuffer(binding_count) => binding_count,
+        } = binding_count;
+    }
 }
 
 impl From<DescriptorInfo> for vk::DescriptorType {
@@ -165,6 +182,21 @@ where
 
         // trace!("descriptor_bindings: {:#?}", &descriptor_bindings);
 
+        let mut bindless_flags = if device
+            .descriptor_indexing_features
+            .descriptor_binding_partially_bound
+        {
+            static BINDLESS_FLAGS: &[vk::DescriptorBindingFlags] =
+                &[vk::DescriptorBindingFlags::PARTIALLY_BOUND];
+
+            Some(
+                vk::DescriptorSetLayoutBindingFlagsCreateInfo::builder()
+                    .binding_flags(BINDLESS_FLAGS),
+            )
+        } else {
+            None
+        };
+
         for descriptor_set_idx in 0..descriptor_set_count {
             // HACK: We need to keep the immutable samplers alive until create, could be cleaner..
             let mut immutable_samplers = vec![];
@@ -204,9 +236,12 @@ where
 
             // trace!("bindings: {:#?}", &bindings);
 
-            let create_info = vk::DescriptorSetLayoutCreateInfo::builder()
-                .bindings(bindings.as_slice())
-                .build();
+            let mut create_info =
+                vk::DescriptorSetLayoutCreateInfo::builder().bindings(bindings.as_slice());
+
+            if let Some(bindless_flags) = bindless_flags.as_mut() {
+                create_info = create_info.push_next(bindless_flags);
+            }
 
             layouts.insert(
                 descriptor_set_idx,

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -2214,7 +2214,6 @@ where
                         .descriptor_bindings()
                         .get(&DescriptorBinding(descriptor_set_idx, dst_binding))
                         .unwrap_or_else(|| panic!("descriptor {descriptor_set_idx}.{dst_binding}[{binding_offset}] specified in recorded execution of pass \"{}\" was not discovered through shader reflection", &pass.name));
-                    let descriptor_count = descriptor_info.binding_count();
                     let descriptor_type = descriptor_info.into();
                     let bound_node = &self.graph.bindings[*node_idx];
                     if let Some(image) = bound_node.as_driver_image() {
@@ -2259,11 +2258,13 @@ where
                                         dst_set: *descriptor_sets[descriptor_set_idx as usize],
                                         dst_binding,
                                         descriptor_type,
-                                        descriptor_count,
+                                        descriptor_count: 1,
                                         ..Default::default()
                                     },
                                 }
                             );
+                        } else {
+                            image_writes.last_mut().unwrap().write.descriptor_count += 1;
                         }
 
                         image_infos.push(vk::DescriptorImageInfo {
@@ -2282,11 +2283,13 @@ where
                                         dst_set: *descriptor_sets[descriptor_set_idx as usize],
                                         dst_binding,
                                         descriptor_type,
-                                        descriptor_count,
+                                        descriptor_count: 1,
                                         ..Default::default()
                                     },
                                 }
                             );
+                        } else {
+                            buffer_writes.last_mut().unwrap().write.descriptor_count += 1;
                         }
 
                         buffer_infos.push(vk::DescriptorBufferInfo {
@@ -2302,10 +2305,12 @@ where
                                     dst_set: *descriptor_sets[descriptor_set_idx as usize],
                                     dst_binding,
                                     descriptor_type,
-                                    descriptor_count,
+                                    descriptor_count: 1,
                                     ..Default::default()
                                 },
                             });
+                        } else {
+                            accel_struct_writes.last_mut().unwrap().write.descriptor_count += 1;
                         }
 
                         accel_struct_infos.push(vk::WriteDescriptorSetAccelerationStructureKHR::builder().acceleration_structures(std::slice::from_ref(accel_struct)).build());


### PR DESCRIPTION
This change:
- Provides descriptor indexing info on `Device` so programs can know if hardware supports bindless
- Allows shaders (compute/graphic/ray trace) to specify unbounded arrays
- Adds example/test code in `fuzzer.rs`
- Fixes an unrelated bug in the "wont merge" fuzzer test case

Programs that want to use bindless will need to understand that when it is not available they should provide a bounded-option; but this change does not address documentation which is lacking overall.