### PR TITLE
Max Image Side from Vulkan Limits.

### DIFF
--- a/contrib/screen-13-egui/src/lib.rs
+++ b/contrib/screen-13-egui/src/lib.rs
@@ -68,10 +68,11 @@ where P: SharedPointerKind + Send + 'static{
             )
             .unwrap(),
         );
+        let max_image_side = device.physical_device.props.limits.max_image_dimension2_d;
         Self {
             ppl,
             ctx: egui::Context::default(),
-            egui_winit: egui_winit::State::new(10000, window),
+            egui_winit: egui_winit::State::new(max_image_side as usize, window),
             textures: HashMap::default(),
             cache: HashPool::new(device),
             next_tex_id: 0,


### PR DESCRIPTION
For debug purposes I had set the max_image_size manually but forgot to change it back this should fix that.