### PR TITLE
Remove archery crate (use std Arc instead)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["game-development", "multimedia::images", "rendering::engine"]
 description = "An easy-to-use Vulkan rendering engine in the spirit of QBasic."
 
 [dependencies]
-archery = "0.4"
 ash = "0.37"
 ash-window = "0.10"
 derive_builder = "0.11"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ pointers. The driver may be created manually for headless rendering or automatic
 built-in event loop abstraction:
 
 ```rust
-// For multi-threaded programs
-use screen_13::prelude_arc::*;
+use screen_13::prelude::*;
 
 fn main() -> Result<(), DisplayError> {
     EventLoop::new().build()?.run(|frame| {

--- a/contrib/screen-13-egui/src/lib.rs
+++ b/contrib/screen-13-egui/src/lib.rs
@@ -1,3 +1,8 @@
+#[deprecated]
+pub mod prelude_arc {
+    pub use super::Egui;
+}
+
 use {
     std::{borrow::Cow, collections::HashMap, sync::Arc},
     bytemuck::cast_slice,

--- a/contrib/screen-13-egui/src/lib.rs
+++ b/contrib/screen-13-egui/src/lib.rs
@@ -1,43 +1,23 @@
-pub mod prelude_arc{
-    pub use super::*;
-
-    use archery::ArcK;
-
-    pub type Egui = super::Egui<ArcK>;
-}
-
-pub mod prelude_rc{
-    pub use super::*;
-
-    use archery::RcK;
-
-    pub type Egui = super::Egui<RcK>;
-}
-
 use {
-    std::{borrow::Cow, collections::HashMap},
-    archery::{SharedPointer, SharedPointerKind},
+    std::{borrow::Cow, collections::HashMap, sync::Arc},
     bytemuck::cast_slice,
-    screen_13::prelude_all::*,
-    screen_13::graph::Bind,
+    screen_13::prelude::*,
 };
 
 
-pub struct Egui<P> 
-where P: SharedPointerKind{
+pub struct Egui {
     pub ctx: egui::Context,
     egui_winit: egui_winit::State,
-    textures: HashMap<egui::TextureId, ImageLeaseBinding<P>>,
-    cache: HashPool<P>,
-    ppl: SharedPointer<GraphicPipeline<P>, P>,
+    textures: HashMap<egui::TextureId, ImageLeaseBinding>,
+    cache: HashPool,
+    ppl: Arc<GraphicPipeline>,
     next_tex_id: u64,
-    user_textures: HashMap<egui::TextureId, AnyImageNode<P>>,
+    user_textures: HashMap<egui::TextureId, AnyImageNode>,
 }
 
-impl<P> Egui<P> 
-where P: SharedPointerKind + Send + 'static{
-    pub fn new(device: &SharedPointer<Device<P>, P>, window: &Window) -> Self {
-        let ppl = SharedPointer::new(
+impl Egui {
+    pub fn new(device: &Arc<Device>, window: &Window) -> Self {
+        let ppl = Arc::new(
             GraphicPipeline::create(
                 device,
                 GraphicPipelineInfo::new()
@@ -83,8 +63,8 @@ where P: SharedPointerKind + Send + 'static{
     fn bind_and_update_textures(
         &mut self,
         deltas: &egui::TexturesDelta,
-        render_graph: &mut RenderGraph<P>,
-    ) -> HashMap<egui::TextureId, AnyImageNode<P>> {
+        render_graph: &mut RenderGraph,
+    ) -> HashMap<egui::TextureId, AnyImageNode> {
         let mut bound_tex = deltas
             .set
             .iter()
@@ -181,8 +161,8 @@ where P: SharedPointerKind + Send + 'static{
 
     fn unbind_and_free(
         &mut self,
-        bound_tex: HashMap<egui::TextureId, AnyImageNode<P>>,
-        render_graph: &mut RenderGraph<P>,
+        bound_tex: HashMap<egui::TextureId, AnyImageNode>,
+        render_graph: &mut RenderGraph,
         deltas: &egui::TexturesDelta,
     ) {
         // Unbind textures
@@ -205,9 +185,9 @@ where P: SharedPointerKind + Send + 'static{
     fn draw_primitive(
         &mut self,
         shapes: Vec<egui::epaint::ClippedShape>,
-        bound_tex: &HashMap<egui::TextureId, AnyImageNode<P>>,
-        render_graph: &mut RenderGraph<P>,
-        target: impl Into<AnyImageNode<P>>,
+        bound_tex: &HashMap<egui::TextureId, AnyImageNode>,
+        render_graph: &mut RenderGraph,
+        target: impl Into<AnyImageNode>,
     ) {
         let target = target.into();
         let target_info = render_graph.node_info(target);
@@ -313,8 +293,8 @@ where P: SharedPointerKind + Send + 'static{
         &mut self,
         window: &Window,
         events: &[Event<()>],
-        target: impl Into<AnyImageNode<P>>,
-        render_graph: &mut RenderGraph<P>,
+        target: impl Into<AnyImageNode>,
+        render_graph: &mut RenderGraph,
         ui_fn: impl FnMut(&egui::Context),
     ) {
         // Update events and generate shapes and texture deltas.
@@ -338,7 +318,7 @@ where P: SharedPointerKind + Send + 'static{
         self.unbind_and_free(bound_tex, render_graph, &deltas);
     }
 
-    pub fn register_texture(&mut self, tex: impl Into<AnyImageNode<P>>) -> egui::TextureId {
+    pub fn register_texture(&mut self, tex: impl Into<AnyImageNode>) -> egui::TextureId {
         let id = egui::TextureId::User(self.next_tex_id);
         self.next_tex_id += 1;
         self.user_textures.insert(id, tex.into());

--- a/contrib/screen-13-fx/Cargo.toml
+++ b/contrib/screen-13-fx/Cargo.toml
@@ -23,7 +23,6 @@ mask-modes = []
 matte-modes = []
 
 [dependencies]
-archery = "0.4"
 bmfont = { version = "0.3", default-features = false }
 bytemuck = "1.9"
 lazy_static = "1.4"

--- a/contrib/screen-13-fx/src/lib.rs
+++ b/contrib/screen-13-fx/src/lib.rs
@@ -1,29 +1,3 @@
-pub mod prelude_arc {
-    pub use super::*;
-
-    use archery::ArcK as P;
-
-    pub type BitmapFont = super::BitmapFont<P>;
-    pub type ComputePresenter = super::ComputePresenter<P>;
-    pub type GraphicPresenter = super::GraphicPresenter<P>;
-    pub type ImageLoader = super::ImageLoader<P>;
-    pub type Transition = super::Transition<P>;
-    pub type TransitionPipeline = super::TransitionPipeline<P>;
-}
-
-pub mod prelude_rc {
-    pub use super::*;
-
-    use archery::RcK as P;
-
-    pub type BitmapFont = super::BitmapFont<P>;
-    pub type ComputePresenter = super::ComputePresenter<P>;
-    pub type GraphicPresenter = super::GraphicPresenter<P>;
-    pub type ImageLoader = super::ImageLoader<P>;
-    pub type Transition = super::Transition<P>;
-    pub type TransitionPipeline = super::TransitionPipeline<P>;
-}
-
 mod bitmap_font;
 mod image_loader;
 mod presenter;

--- a/contrib/screen-13-fx/src/lib.rs
+++ b/contrib/screen-13-fx/src/lib.rs
@@ -1,3 +1,11 @@
+#[deprecated]
+pub mod prelude_arc {
+    pub use super::{
+        BitmapFont, BitmapGlyphColor, ComputePresenter, GraphicPresenter, ImageFormat, ImageLoader,
+        Transition, TransitionPipeline,
+    };
+}
+
 mod bitmap_font;
 mod image_loader;
 mod presenter;

--- a/contrib/screen-13-imgui/Cargo.toml
+++ b/contrib/screen-13-imgui/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-archery = "0.4"
 bytemuck = "1.9"
 imgui = "0.8"
 imgui-winit-support = { version = "0.8", default-features = false, features = ["winit-26"] }

--- a/contrib/screen-13-imgui/src/lib.rs
+++ b/contrib/screen-13-imgui/src/lib.rs
@@ -1,3 +1,8 @@
+#[deprecated]
+pub mod prelude_arc {
+    pub use super::{imgui, Condition, ImGui, Ui};
+}
+
 pub use imgui::{self, Condition, Ui};
 
 use {

--- a/contrib/screen-13-imgui/src/lib.rs
+++ b/contrib/screen-13-imgui/src/lib.rs
@@ -1,52 +1,29 @@
-pub mod prelude_arc {
-    pub use super::*;
-
-    use archery::ArcK;
-
-    pub type ImGui = super::ImGui<ArcK>;
-}
-
-pub mod prelude_rc {
-    pub use super::*;
-
-    use archery::RcK;
-
-    pub type ImGui = super::ImGui<RcK>;
-}
-
 pub use imgui::{self, Condition, Ui};
 
 use {
-    archery::{SharedPointer, SharedPointerKind},
     bytemuck::cast_slice,
     imgui::{Context, DrawCmd, DrawCmdParams},
     imgui_winit_support::{HiDpiMode, WinitPlatform},
     inline_spirv::include_spirv,
-    screen_13::prelude_all::*,
-    std::time::Duration,
+    screen_13::prelude::*,
+    std::{sync::Arc, time::Duration},
 };
 
 #[derive(Debug)]
-pub struct ImGui<P>
-where
-    P: SharedPointerKind,
-{
+pub struct ImGui {
     context: Context,
-    font_atlas_image: Option<ImageLeaseBinding<P>>,
-    pipeline: SharedPointer<GraphicPipeline<P>, P>,
+    font_atlas_image: Option<ImageLeaseBinding>,
+    pipeline: Arc<GraphicPipeline>,
     platform: WinitPlatform,
-    pool: HashPool<P>,
+    pool: HashPool,
 }
 
-impl<P> ImGui<P>
-where
-    P: SharedPointerKind + Send + 'static,
-{
-    pub fn new(device: &SharedPointer<Device<P>, P>) -> Self {
+impl ImGui {
+    pub fn new(device: &Arc<Device>) -> Self {
         let mut context = Context::create();
         let platform = WinitPlatform::init(&mut context);
         let pool = HashPool::new(device);
-        let pipeline = SharedPointer::new(
+        let pipeline = Arc::new(
             GraphicPipeline::create(
                 device,
                 GraphicPipelineInfo::new()
@@ -75,9 +52,9 @@ where
         dt: f32,
         events: &[Event<'_, ()>],
         window: &Window,
-        render_graph: &mut RenderGraph<P>,
+        render_graph: &mut RenderGraph,
         ui_func: impl FnOnce(&mut Ui),
-    ) -> ImageLeaseNode<P> {
+    ) -> ImageLeaseNode {
         let hidpi = self.platform.hidpi_factor();
 
         self.platform
@@ -231,9 +208,9 @@ where
 
     pub fn draw_frame(
         &mut self,
-        frame: &mut FrameContext<'_, P>,
+        frame: &mut FrameContext<'_>,
         ui_func: impl FnOnce(&mut Ui),
-    ) -> ImageLeaseNode<P> {
+    ) -> ImageLeaseNode {
         self.draw(
             frame.dt,
             frame.events,
@@ -243,7 +220,7 @@ where
         )
     }
 
-    fn lease_font_atlas_image(&mut self, render_graph: &mut RenderGraph<P>) {
+    fn lease_font_atlas_image(&mut self, render_graph: &mut RenderGraph) {
         use imgui::{FontConfig, FontGlyphRanges, FontSource};
 
         let hidpi_factor = self.platform.hidpi_factor();

--- a/examples/debugger.rs
+++ b/examples/debugger.rs
@@ -24,7 +24,7 @@
     To continue, uncomment line 30.
 */
 fn main() -> Result<(), screen_13::DisplayError> {
-    use screen_13::prelude_arc::*;
+    use {screen_13::prelude::*, std::sync::Arc};
 
     // 👋, 🌎!
     //pretty_env_logger::init();
@@ -126,7 +126,7 @@ fn main() -> Result<(), screen_13::DisplayError> {
         );
 
         // Note: This is just for example
-        let compute_pipeline = Shared::new(
+        let compute_pipeline = Arc::new(
             ComputePipeline::create(
                 frame.device,
                 inline_spirv::inline_spirv!(

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -1,4 +1,4 @@
-use screen_13::prelude_arc::*;
+use screen_13::prelude::*;
 use screen_13_egui::*;
 
 fn main() -> Result<(), DisplayError> {

--- a/examples/font_bmp.rs
+++ b/examples/font_bmp.rs
@@ -3,8 +3,8 @@ use inline_spirv::inline_spirv;
 use {
     bmfont::{BMFont, OrdinateOrientation},
     image::io::Reader,
-    screen_13::prelude_arc::*,
-    screen_13_fx::prelude_arc::*,
+    screen_13::prelude::*,
+    screen_13_fx::*,
     std::{io::Cursor, time::Instant},
 };
 

--- a/examples/getting-started.md
+++ b/examples/getting-started.md
@@ -3,7 +3,7 @@
 This guide is intended for developers who are new to _Screen 13_ and want a step-by-step introduction. For further details on these
 topics refer to the online [documentation](https://docs.rs/screen-13).
 
-All sample code in this guide is assuming a `use screen_13::prelude_arc::*`.
+All sample code in this guide is assuming `use screen_13::prelude::*`.
 
 ## Required Packages
 
@@ -21,10 +21,7 @@ _Windows_:
 
 The `driver` module provides a `Driver` struct which provides a ready-to-use Ash Vulkan instance/device/swapchain. The driver itself,
 as well as any buffers, images, or other resources created from them, use shared reference tracking to keep pointers alive. _Screen 13_
-uses a generic type parameter to determine what type of reference tracking to use: `std::rc::Rc` or `std::sync::Arc`.
-
-Most programs will use the `screen_13::prelude_arc::*` prelude because it provides concrete type aliases which do not
-have generic parameters for shared references.
+uses `std::sync::Arc` to track references.
 
 Creating a driver uses a configuration struct to enable or disable features:
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,4 +1,4 @@
-use screen_13::prelude_arc::{run, DisplayError};
+use screen_13::prelude::{run, DisplayError};
 
 /// This example requires a color graphics adapter.
 fn main() -> Result<(), DisplayError> {

--- a/examples/imgui.rs
+++ b/examples/imgui.rs
@@ -1,5 +1,5 @@
 use {
-    screen_13::prelude_arc::*,
+    screen_13::prelude::*,
     screen_13_fx::*,
     screen_13_imgui::{imgui, Condition, ImGui},
 };

--- a/examples/multipass.rs
+++ b/examples/multipass.rs
@@ -2,7 +2,8 @@ use {
     bytemuck::cast_slice,
     glam::{Mat4, Vec4},
     inline_spirv::inline_spirv,
-    screen_13::prelude_arc::*,
+    screen_13::prelude::*,
+    std::sync::Arc,
 };
 
 // NOTE: When this example runs, there will be a blank screen - that's OK!
@@ -204,7 +205,7 @@ fn image_info_2d(width: u32, height: u32) -> ImageInfo {
     // .sample_count(SampleCount::X1)
 }
 
-fn create_fill_quad_linear_gradient_pipeline(device: &Shared<Device>) -> Shared<GraphicPipeline> {
+fn create_fill_quad_linear_gradient_pipeline(device: &Arc<Device>) -> Arc<GraphicPipeline> {
     let vertex_shader = Shader::new_vertex(
         inline_spirv!(
             r#"
@@ -250,7 +251,7 @@ fn create_fill_quad_linear_gradient_pipeline(device: &Shared<Device>) -> Shared<
         .as_slice(),
     );
 
-    Shared::new(
+    Arc::new(
         GraphicPipeline::create(
             device,
             GraphicPipelineInfo::new().blend(BlendMode::ALPHA),
@@ -261,7 +262,7 @@ fn create_fill_quad_linear_gradient_pipeline(device: &Shared<Device>) -> Shared<
 }
 
 // Oh please somebody PR a really nice shader here
-fn create_draw_funky_shape_deferred_pipeline(device: &Shared<Device>) -> Shared<GraphicPipeline> {
+fn create_draw_funky_shape_deferred_pipeline(device: &Arc<Device>) -> Arc<GraphicPipeline> {
     let vertex_shader = Shader::new_vertex(
         inline_spirv!(
             r#"
@@ -309,7 +310,7 @@ fn create_draw_funky_shape_deferred_pipeline(device: &Shared<Device>) -> Shared<
         .as_slice(),
     );
 
-    Shared::new(
+    Arc::new(
         GraphicPipeline::create(
             device,
             GraphicPipelineInfo::new()

--- a/examples/ray_trace.rs
+++ b/examples/ray_trace.rs
@@ -1,8 +1,8 @@
 use {
     bytemuck::cast_slice,
     inline_spirv::inline_spirv,
-    screen_13::prelude_arc::*,
-    std::{io::BufReader, mem::size_of},
+    screen_13::prelude::*,
+    std::{io::BufReader, mem::size_of, sync::Arc},
     tobj::{load_mtl_buf, load_obj_buf, GPU_LOAD_OPTIONS},
 };
 
@@ -326,10 +326,8 @@ fn align_up(val: u32, atom: u32) -> u32 {
     (val + atom - 1) & !(atom - 1)
 }
 
-fn create_ray_trace_pipeline(
-    device: &Shared<Device>,
-) -> Result<Shared<RayTracePipeline>, DriverError> {
-    Ok(Shared::new(RayTracePipeline::create(
+fn create_ray_trace_pipeline(device: &Arc<Device>) -> Result<Arc<RayTracePipeline>, DriverError> {
+    Ok(Arc::new(RayTracePipeline::create(
         device,
         RayTracePipelineInfo::new()
             .max_ray_recursion_depth(1)
@@ -350,7 +348,7 @@ fn create_ray_trace_pipeline(
 }
 
 fn load_scene_buffers(
-    device: &Shared<Device>,
+    device: &Arc<Device>,
 ) -> Result<
     (
         Option<BufferBinding>,

--- a/examples/shader-toy/src/main.rs
+++ b/examples/shader-toy/src/main.rs
@@ -36,9 +36,9 @@ use {
     anyhow::Context,
     bytemuck::{bytes_of, Pod, Zeroable},
     pak::{buf::PakBuf, Pak},
-    screen_13::prelude_arc::*,
+    screen_13::prelude::*,
     screen_13_fx::*,
-    std::time::Instant,
+    std::{sync::Arc, time::Instant},
 };
 
 fn main() -> anyhow::Result<()> {
@@ -87,7 +87,7 @@ fn main() -> anyhow::Result<()> {
     // no depth/stencil
     // 1x sample count
     // one-sided
-    let buffer_pipeline = Shared::new(
+    let buffer_pipeline = Arc::new(
         GraphicPipeline::create(
             &event_loop.device,
             GraphicPipelineInfo::default(),
@@ -98,7 +98,7 @@ fn main() -> anyhow::Result<()> {
         )
         .context("FLOCKAROO_BUF_FRAG")?,
     );
-    let image_pipeline = Shared::new(
+    let image_pipeline = Arc::new(
         GraphicPipeline::create(
             &event_loop.device,
             GraphicPipelineInfo::default(),

--- a/examples/transitions.rs
+++ b/examples/transitions.rs
@@ -1,7 +1,7 @@
 use {
     image::io::Reader,
-    screen_13::prelude_arc::*,
-    screen_13_fx::prelude_arc::*,
+    screen_13::prelude::*,
+    screen_13_fx::*,
     screen_13_imgui::*,
     std::{io::Cursor, time::Instant},
 };
@@ -197,7 +197,7 @@ const TRANSITIONS: [Transition; 80] = [
         direction: [1.0, -1.0],
     },
     // Transition::Displacement {
-    //     displacement_map: AnyImageNode<P>,
+    //     displacement_map: AnyImageNode,
     //     strength: f32,
     // },
     Transition::DoomScreen {
@@ -252,7 +252,7 @@ const TRANSITIONS: [Transition; 80] = [
     Transition::LeftRight,
     Transition::LinearBlur { intensity: 0.1 },
     // Transition::Luma {
-    //     luma_map: AnyImageNode<P>,
+    //     luma_map: AnyImageNode,
     // },
     Transition::LuminanceMelt {
         direction: true,

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -1,4 +1,4 @@
-use {bytemuck::cast_slice, inline_spirv::inline_spirv, screen_13::prelude_arc::*};
+use {bytemuck::cast_slice, inline_spirv::inline_spirv, screen_13::prelude::*};
 
 // A Vulkan triangle using a graphic pipeline, vertex/fragment shaders, and index/vertex buffers.
 fn main() -> Result<(), DisplayError> {

--- a/src/device_api.rs
+++ b/src/device_api.rs
@@ -4,32 +4,29 @@ use {
             Buffer, BufferInfo, ComputePipeline, ComputePipelineInfo, GraphicPipeline,
             GraphicPipelineInfo, Image, ImageInfo, Shader,
         },
+        event_loop::EventLoop,
         graph::ImageBinding,
-        EventLoop,
     },
-    archery::{SharedPointer, SharedPointerKind},
+    std::sync::Arc,
 };
 
-impl<P> EventLoop<P>
-where
-    P: SharedPointerKind + Send,
-{
-    pub fn new_buffer(&self, info: impl Into<BufferInfo>) -> SharedPointer<Buffer<P>, P> {
-        SharedPointer::new(Buffer::create(&self.device, info).unwrap())
+impl EventLoop {
+    pub fn new_buffer(&self, info: impl Into<BufferInfo>) -> Arc<Buffer> {
+        Arc::new(Buffer::create(&self.device, info).unwrap())
     }
 
     pub fn new_compute_pipeline(
         &self,
         info: impl Into<ComputePipelineInfo>,
-    ) -> SharedPointer<ComputePipeline<P>, P> {
-        SharedPointer::new(ComputePipeline::create(&self.device, info).unwrap())
+    ) -> Arc<ComputePipeline> {
+        Arc::new(ComputePipeline::create(&self.device, info).unwrap())
     }
 
-    pub fn new_image(&self, info: impl Into<ImageInfo>) -> ImageBinding<P> {
+    pub fn new_image(&self, info: impl Into<ImageInfo>) -> ImageBinding {
         ImageBinding::new(self.new_image_raw(info))
     }
 
-    pub fn new_image_raw(&self, info: impl Into<ImageInfo>) -> Image<P> {
+    pub fn new_image_raw(&self, info: impl Into<ImageInfo>) -> Image {
         Image::create(&self.device, info).unwrap()
     }
 
@@ -37,10 +34,10 @@ where
         &self,
         info: impl Into<GraphicPipelineInfo>,
         shaders: impl IntoIterator<Item = S>,
-    ) -> SharedPointer<GraphicPipeline<P>, P>
+    ) -> Arc<GraphicPipeline>
     where
         S: Into<Shader>,
     {
-        SharedPointer::new(GraphicPipeline::create(&self.device, info, shaders).unwrap())
+        Arc::new(GraphicPipeline::create(&self.device, info, shaders).unwrap())
     }
 }

--- a/src/driver/descriptor_set_layout.rs
+++ b/src/driver/descriptor_set_layout.rs
@@ -1,32 +1,22 @@
 use {
     super::{Device, DriverError},
-    archery::{SharedPointer, SharedPointerKind},
     ash::vk,
     log::warn,
-    std::{ops::Deref, thread::panicking},
+    std::{ops::Deref, sync::Arc, thread::panicking},
 };
 
 #[derive(Debug)]
-pub struct DescriptorSetLayout<P>
-where
-    P: SharedPointerKind,
-{
-    device: SharedPointer<Device<P>, P>,
+pub struct DescriptorSetLayout {
+    device: Arc<Device>,
     descriptor_set_layout: vk::DescriptorSetLayout,
 }
 
-impl<P> DescriptorSetLayout<P>
-where
-    P: SharedPointerKind,
-{
+impl DescriptorSetLayout {
     pub fn create(
-        device: &SharedPointer<Device<P>, P>,
+        device: &Arc<Device>,
         info: &vk::DescriptorSetLayoutCreateInfo,
-    ) -> Result<Self, DriverError>
-    where
-        P: SharedPointerKind,
-    {
-        let device = SharedPointer::clone(device);
+    ) -> Result<Self, DriverError> {
+        let device = Arc::clone(device);
         let descriptor_set_layout = unsafe {
             device
                 .create_descriptor_set_layout(info, None)
@@ -44,10 +34,7 @@ where
     }
 }
 
-impl<P> Deref for DescriptorSetLayout<P>
-where
-    P: SharedPointerKind,
-{
+impl Deref for DescriptorSetLayout {
     type Target = vk::DescriptorSetLayout;
 
     fn deref(&self) -> &Self::Target {
@@ -55,10 +42,7 @@ where
     }
 }
 
-impl<P> Drop for DescriptorSetLayout<P>
-where
-    P: SharedPointerKind,
-{
+impl Drop for DescriptorSetLayout {
     fn drop(&mut self) {
         if panicking() {
             return;

--- a/src/driver/physical_device.rs
+++ b/src/driver/physical_device.rs
@@ -1,11 +1,11 @@
 use {
     super::{Instance, Surface},
-    archery::{SharedPointer, SharedPointerKind},
     ash::vk,
     std::{
         ffi::CStr,
         fmt::{Debug, Formatter},
         ops::Deref,
+        sync::Arc,
     },
 };
 
@@ -46,14 +46,11 @@ impl PhysicalDevice {
         }
     }
 
-    pub fn has_presentation_support<P>(
+    pub fn has_presentation_support(
         _this: &Self,
-        _instance: &SharedPointer<Instance, P>,
-        _surface: &Surface<P>,
-    ) -> bool
-    where
-        P: SharedPointerKind,
-    {
+        _instance: &Arc<Instance>,
+        _surface: &Surface,
+    ) -> bool {
         // if let Ok(device) = Device::create(
         //     instance,
         //     this.clone(),

--- a/src/driver/surface.rs
+++ b/src/driver/surface.rs
@@ -1,34 +1,28 @@
 use {
     super::{DriverError, Instance},
-    archery::{SharedPointer, SharedPointerKind},
     ash::{extensions::khr, vk},
     log::warn,
     raw_window_handle::HasRawWindowHandle,
     std::{
         fmt::{Debug, Formatter},
         ops::Deref,
+        sync::Arc,
         thread::panicking,
     },
 };
 
-pub struct Surface<P>
-where
-    P: SharedPointerKind,
-{
-    _instance: SharedPointer<Instance, P>,
+pub struct Surface {
+    _instance: Arc<Instance>,
     surface: vk::SurfaceKHR,
     surface_ext: khr::Surface,
 }
 
-impl<P> Surface<P>
-where
-    P: SharedPointerKind,
-{
+impl Surface {
     pub fn new(
-        instance: &SharedPointer<Instance, P>,
+        instance: &Arc<Instance>,
         window: &impl HasRawWindowHandle,
     ) -> Result<Self, DriverError> {
-        let instance = SharedPointer::clone(instance);
+        let instance = Arc::clone(instance);
         let surface_ext = khr::Surface::new(&instance.entry, &instance);
         let surface =
             unsafe { ash_window::create_surface(&instance.entry, &instance, window, None) }
@@ -46,19 +40,13 @@ where
     }
 }
 
-impl<P> Debug for Surface<P>
-where
-    P: SharedPointerKind,
-{
+impl Debug for Surface {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str("Surface")
     }
 }
 
-impl<P> Deref for Surface<P>
-where
-    P: SharedPointerKind,
-{
+impl Deref for Surface {
     type Target = vk::SurfaceKHR;
 
     fn deref(&self) -> &Self::Target {
@@ -66,10 +54,7 @@ where
     }
 }
 
-impl<P> Drop for Surface<P>
-where
-    P: SharedPointerKind,
-{
+impl Drop for Surface {
     fn drop(&mut self) {
         if panicking() {
             return;

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -3,7 +3,7 @@ use {
         driver::Device,
         graph::{RenderGraph, SwapchainImageNode},
     },
-    archery::{SharedPointer, SharedPointerKind},
+    std::sync::Arc,
     winit::{dpi::PhysicalPosition, event::Event, window::Window},
 };
 
@@ -19,25 +19,19 @@ pub fn set_cursor_position(window: &Window, x: u32, y: u32) {
     window.set_cursor_position(position).unwrap_or_default();
 }
 
-pub struct FrameContext<'a, P>
-where
-    P: SharedPointerKind,
-{
-    pub device: &'a SharedPointer<Device<P>, P>,
+pub struct FrameContext<'a> {
+    pub device: &'a Arc<Device>,
     pub dt: f32,
     pub events: &'a [Event<'a, ()>],
     pub height: u32,
-    pub render_graph: &'a mut RenderGraph<P>,
-    pub swapchain_image: SwapchainImageNode<P>,
+    pub render_graph: &'a mut RenderGraph,
+    pub swapchain_image: SwapchainImageNode,
     pub will_exit: &'a mut bool,
     pub width: u32,
     pub window: &'a Window,
 }
 
-impl<P> FrameContext<'_, P>
-where
-    P: SharedPointerKind,
-{
+impl FrameContext<'_> {
     pub fn exit(&mut self) {
         *self.will_exit = true;
     }

--- a/src/graph/info.rs
+++ b/src/graph/info.rs
@@ -4,22 +4,21 @@ use {
         ImageLeaseNode, ImageNode, RenderGraph, SwapchainImageNode,
     },
     crate::driver::{AccelerationStructureInfo, BufferInfo, ImageInfo},
-    archery::SharedPointerKind,
 };
 
 pub trait Information {
     type Info;
 
-    fn get(self, graph: &RenderGraph<impl SharedPointerKind + Send>) -> Self::Info;
+    fn get(self, graph: &RenderGraph) -> Self::Info;
 }
 
 macro_rules! information {
     ($name:ident: $src:ident -> $dst:ident) => {
         paste::paste! {
-            impl<P> Information for $src<P> {
+            impl Information for $src {
                 type Info = $dst;
 
-                fn get(self, graph: &RenderGraph<impl SharedPointerKind>) -> $dst {
+                fn get(self, graph: &RenderGraph) -> $dst {
                     graph.bindings[self.idx].[<as_ $name>]().unwrap().info().clone()
                 }
             }

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -8,28 +8,27 @@ use {
         vk, AccelerationStructureInfo, BufferInfo, BufferSubresource, ImageInfo, ImageSubresource,
         ImageViewInfo,
     },
-    archery::{SharedPointer, SharedPointerKind},
-    std::{marker::PhantomData, ops::Range},
+    std::{ops::Range, sync::Arc},
 };
 
 #[derive(Debug)]
-pub enum AnyAccelerationStructureNode<P> {
-    AccelerationStructure(AccelerationStructureNode<P>),
-    AccelerationStructureLease(AccelerationStructureLeaseNode<P>),
+pub enum AnyAccelerationStructureNode {
+    AccelerationStructure(AccelerationStructureNode),
+    AccelerationStructureLease(AccelerationStructureLeaseNode),
 }
 
-impl<P> Clone for AnyAccelerationStructureNode<P> {
+impl Clone for AnyAccelerationStructureNode {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<P> Copy for AnyAccelerationStructureNode<P> {}
+impl Copy for AnyAccelerationStructureNode {}
 
-impl<P> Information for AnyAccelerationStructureNode<P> {
+impl Information for AnyAccelerationStructureNode {
     type Info = AccelerationStructureInfo;
 
-    fn get(self, graph: &RenderGraph<impl SharedPointerKind + Send>) -> Self::Info {
+    fn get(self, graph: &RenderGraph) -> Self::Info {
         match self {
             Self::AccelerationStructure(node) => node.get(graph),
             Self::AccelerationStructureLease(node) => node.get(graph),
@@ -37,19 +36,19 @@ impl<P> Information for AnyAccelerationStructureNode<P> {
     }
 }
 
-impl<P> From<AccelerationStructureNode<P>> for AnyAccelerationStructureNode<P> {
-    fn from(node: AccelerationStructureNode<P>) -> Self {
+impl From<AccelerationStructureNode> for AnyAccelerationStructureNode {
+    fn from(node: AccelerationStructureNode) -> Self {
         Self::AccelerationStructure(node)
     }
 }
 
-impl<P> From<AccelerationStructureLeaseNode<P>> for AnyAccelerationStructureNode<P> {
-    fn from(node: AccelerationStructureLeaseNode<P>) -> Self {
+impl From<AccelerationStructureLeaseNode> for AnyAccelerationStructureNode {
+    fn from(node: AccelerationStructureLeaseNode) -> Self {
         Self::AccelerationStructureLease(node)
     }
 }
 
-impl<P> Node<P> for AnyAccelerationStructureNode<P> {
+impl Node for AnyAccelerationStructureNode {
     fn index(self) -> NodeIndex {
         match self {
             Self::AccelerationStructure(node) => node.index(),
@@ -59,23 +58,23 @@ impl<P> Node<P> for AnyAccelerationStructureNode<P> {
 }
 
 #[derive(Debug)]
-pub enum AnyBufferNode<P> {
-    Buffer(BufferNode<P>),
-    BufferLease(BufferLeaseNode<P>),
+pub enum AnyBufferNode {
+    Buffer(BufferNode),
+    BufferLease(BufferLeaseNode),
 }
 
-impl<P> Clone for AnyBufferNode<P> {
+impl Clone for AnyBufferNode {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<P> Copy for AnyBufferNode<P> {}
+impl Copy for AnyBufferNode {}
 
-impl<P> Information for AnyBufferNode<P> {
+impl Information for AnyBufferNode {
     type Info = BufferInfo;
 
-    fn get(self, graph: &RenderGraph<impl SharedPointerKind + Send>) -> Self::Info {
+    fn get(self, graph: &RenderGraph) -> Self::Info {
         match self {
             Self::Buffer(node) => node.get(graph),
             Self::BufferLease(node) => node.get(graph),
@@ -83,19 +82,19 @@ impl<P> Information for AnyBufferNode<P> {
     }
 }
 
-impl<P> From<BufferNode<P>> for AnyBufferNode<P> {
-    fn from(node: BufferNode<P>) -> Self {
+impl From<BufferNode> for AnyBufferNode {
+    fn from(node: BufferNode) -> Self {
         Self::Buffer(node)
     }
 }
 
-impl<P> From<BufferLeaseNode<P>> for AnyBufferNode<P> {
-    fn from(node: BufferLeaseNode<P>) -> Self {
+impl From<BufferLeaseNode> for AnyBufferNode {
+    fn from(node: BufferLeaseNode) -> Self {
         Self::BufferLease(node)
     }
 }
 
-impl<P> Node<P> for AnyBufferNode<P> {
+impl Node for AnyBufferNode {
     fn index(self) -> NodeIndex {
         match self {
             Self::Buffer(node) => node.index(),
@@ -105,24 +104,24 @@ impl<P> Node<P> for AnyBufferNode<P> {
 }
 
 #[derive(Debug)]
-pub enum AnyImageNode<P> {
-    Image(ImageNode<P>),
-    ImageLease(ImageLeaseNode<P>),
-    SwapchainImage(SwapchainImageNode<P>),
+pub enum AnyImageNode {
+    Image(ImageNode),
+    ImageLease(ImageLeaseNode),
+    SwapchainImage(SwapchainImageNode),
 }
 
-impl<P> Clone for AnyImageNode<P> {
+impl Clone for AnyImageNode {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<P> Copy for AnyImageNode<P> {}
+impl Copy for AnyImageNode {}
 
-impl<P> Information for AnyImageNode<P> {
+impl Information for AnyImageNode {
     type Info = ImageInfo;
 
-    fn get(self, graph: &RenderGraph<impl SharedPointerKind + Send>) -> Self::Info {
+    fn get(self, graph: &RenderGraph) -> Self::Info {
         match self {
             Self::Image(node) => node.get(graph),
             Self::ImageLease(node) => node.get(graph),
@@ -131,25 +130,25 @@ impl<P> Information for AnyImageNode<P> {
     }
 }
 
-impl<P> From<ImageNode<P>> for AnyImageNode<P> {
-    fn from(node: ImageNode<P>) -> Self {
+impl From<ImageNode> for AnyImageNode {
+    fn from(node: ImageNode) -> Self {
         Self::Image(node)
     }
 }
 
-impl<P> From<ImageLeaseNode<P>> for AnyImageNode<P> {
-    fn from(node: ImageLeaseNode<P>) -> Self {
+impl From<ImageLeaseNode> for AnyImageNode {
+    fn from(node: ImageLeaseNode) -> Self {
         Self::ImageLease(node)
     }
 }
 
-impl<P> From<SwapchainImageNode<P>> for AnyImageNode<P> {
-    fn from(node: SwapchainImageNode<P>) -> Self {
+impl From<SwapchainImageNode> for AnyImageNode {
+    fn from(node: SwapchainImageNode) -> Self {
         Self::SwapchainImage(node)
     }
 }
 
-impl<P> Node<P> for AnyImageNode<P> {
+impl Node for AnyImageNode {
     fn index(self) -> NodeIndex {
         match self {
             Self::Image(node) => node.index(),
@@ -159,7 +158,7 @@ impl<P> Node<P> for AnyImageNode<P> {
     }
 }
 
-pub trait Node<P>: Copy {
+pub trait Node: Copy {
     fn index(self) -> NodeIndex;
 }
 
@@ -167,29 +166,27 @@ macro_rules! node {
     ($name:ident) => {
         paste::paste! {
             #[derive(Debug)]
-            pub struct [<$name Node>]<P> {
-                __: PhantomData<P>,
+            pub struct [<$name Node>] {
                 pub(super) idx: NodeIndex,
             }
 
-            impl<P> [<$name Node>]<P> {
+            impl [<$name Node>] {
                 pub(super) fn new(idx: NodeIndex) -> Self {
                     Self {
-                        __: PhantomData,
                         idx,
                     }
                 }
             }
 
-            impl<P> Clone for [<$name Node>]<P> {
+            impl Clone for [<$name Node>] {
                 fn clone(&self) -> Self {
                     *self
                 }
             }
 
-            impl<P> Copy for [<$name Node>]<P> {}
+            impl Copy for [<$name Node>] {}
 
-            impl<P> Node<P> for [<$name Node>]<P>  {
+            impl Node for [<$name Node>] {
                 fn index(self) -> NodeIndex {
                     self.idx
                 }
@@ -209,14 +206,11 @@ node!(SwapchainImage);
 macro_rules! node_unbind {
     ($name:ident) => {
         paste::paste! {
-            impl<P> Unbind<RenderGraph<P>, [<$name Binding>]<P>> for [<$name Node>]<P>
-            where
-                P: SharedPointerKind + Send + 'static,
-            {
-                fn unbind(self, graph: &mut RenderGraph<P>) -> [<$name Binding>]<P> {
+            impl Unbind<RenderGraph, [<$name Binding>]> for [<$name Node>] {
+                fn unbind(self, graph: &mut RenderGraph) -> [<$name Binding>] {
                     let binding = {
                         let binding = graph.bindings[self.idx].[<as_ $name:snake>]().unwrap();
-                        let item = SharedPointer::clone(&binding.item);
+                        let item = Arc::clone(&binding.item);
 
                         // When unbinding we return a binding that has the last access type set to
                         // whatever the last acccess in the graph was (because it will be valid once
@@ -243,11 +237,8 @@ node_unbind!(Image);
 macro_rules! node_unbind_lease {
     ($name:ident) => {
         paste::paste! {
-            impl<P> Unbind<RenderGraph<P>, [<$name LeaseBinding>]<P>> for [<$name LeaseNode>]<P>
-            where
-                P: SharedPointerKind + Send + 'static,
-            {
-                fn unbind(self, graph: &mut RenderGraph<P>) -> [<$name LeaseBinding>]<P> {
+            impl Unbind<RenderGraph, [<$name LeaseBinding>]> for [<$name LeaseNode>] {
+                fn unbind(self, graph: &mut RenderGraph) -> [<$name LeaseBinding>] {
                     let binding = {
                         let last_access = graph.last_access(self);
                         let (binding, _) = graph.bindings[self.idx].[<as_ $name:snake _lease_mut>]().unwrap();
@@ -286,7 +277,7 @@ pub trait Unbind<Graph, Binding> {
     fn unbind(self, graph: &mut Graph) -> Binding;
 }
 
-pub trait View<P>: Node<P>
+pub trait View: Node
 where
     Self::Information: Clone,
     Self::Subresource: Into<Subresource>,
@@ -295,52 +286,52 @@ where
     type Subresource;
 }
 
-impl<P> View<P> for AccelerationStructureNode<P> {
+impl View for AccelerationStructureNode {
     type Information = ();
     type Subresource = ();
 }
 
-impl<P> View<P> for AccelerationStructureLeaseNode<P> {
+impl View for AccelerationStructureLeaseNode {
     type Information = ();
     type Subresource = ();
 }
 
-impl<P> View<P> for AnyAccelerationStructureNode<P> {
+impl View for AnyAccelerationStructureNode {
     type Information = ();
     type Subresource = ();
 }
 
-impl<P> View<P> for AnyBufferNode<P> {
+impl View for AnyBufferNode {
     type Information = BufferSubresource;
     type Subresource = BufferSubresource;
 }
 
-impl<P> View<P> for AnyImageNode<P> {
+impl View for AnyImageNode {
     type Information = ImageViewInfo;
     type Subresource = ImageSubresource;
 }
 
-impl<P> View<P> for BufferLeaseNode<P> {
+impl View for BufferLeaseNode {
     type Information = BufferSubresource;
     type Subresource = BufferSubresource;
 }
 
-impl<P> View<P> for BufferNode<P> {
+impl View for BufferNode {
     type Information = BufferSubresource;
     type Subresource = BufferSubresource;
 }
 
-impl<P> View<P> for ImageLeaseNode<P> {
+impl View for ImageLeaseNode {
     type Information = ImageViewInfo;
     type Subresource = ImageSubresource;
 }
 
-impl<P> View<P> for ImageNode<P> {
+impl View for ImageNode {
     type Information = ImageViewInfo;
     type Subresource = ImageSubresource;
 }
 
-impl<P> View<P> for SwapchainImageNode<P> {
+impl View for SwapchainImageNode {
     type Information = ImageViewInfo;
     type Subresource = ImageSubresource;
 }

--- a/src/graph/swapchain.rs
+++ b/src/graph/swapchain.rs
@@ -1,29 +1,22 @@
 use {
     super::{Bind, Binding, RenderGraph, Resolver, SwapchainImageNode, Unbind},
     crate::driver::SwapchainImage,
-    archery::SharedPointerKind,
     std::{fmt::Debug, mem::replace},
     vk_sync::AccessType,
 };
 
 #[derive(Debug)]
-pub struct SwapchainImageBinding<P>
-where
-    P: SharedPointerKind,
-{
-    pub(super) item: SwapchainImage<P>,
+pub struct SwapchainImageBinding {
+    pub(super) item: SwapchainImage,
     pub(super) access: AccessType,
 }
 
-impl<P> SwapchainImageBinding<P>
-where
-    P: SharedPointerKind,
-{
-    pub(super) fn new(item: SwapchainImage<P>) -> Self {
+impl SwapchainImageBinding {
+    pub(super) fn new(item: SwapchainImage) -> Self {
         Self::new_unbind(item, AccessType::Nothing)
     }
 
-    pub(super) fn new_unbind(item: SwapchainImage<P>, access: AccessType) -> Self {
+    pub(super) fn new_unbind(item: SwapchainImage, access: AccessType) -> Self {
         Self { item, access }
     }
 
@@ -34,11 +27,8 @@ where
     }
 }
 
-impl<P> Bind<&mut RenderGraph<P>, SwapchainImageNode<P>, P> for SwapchainImage<P>
-where
-    P: SharedPointerKind,
-{
-    fn bind(self, graph: &mut RenderGraph<P>) -> SwapchainImageNode<P> {
+impl Bind<&mut RenderGraph, SwapchainImageNode> for SwapchainImage {
+    fn bind(self, graph: &mut RenderGraph) -> SwapchainImageNode {
         // We will return a new node
         let res = SwapchainImageNode::new(graph.bindings.len());
 
@@ -51,11 +41,8 @@ where
     }
 }
 
-impl<P> Bind<&mut RenderGraph<P>, SwapchainImageNode<P>, P> for SwapchainImageBinding<P>
-where
-    P: SharedPointerKind,
-{
-    fn bind(self, graph: &mut RenderGraph<P>) -> SwapchainImageNode<P> {
+impl Bind<&mut RenderGraph, SwapchainImageNode> for SwapchainImageBinding {
+    fn bind(self, graph: &mut RenderGraph) -> SwapchainImageNode {
         // We will return a new node
         let res = SwapchainImageNode::new(graph.bindings.len());
 
@@ -65,11 +52,8 @@ where
     }
 }
 
-impl<P> Binding<P>
-where
-    P: SharedPointerKind,
-{
-    pub(super) fn as_swapchain_image(&self) -> Option<&SwapchainImageBinding<P>> {
+impl Binding {
+    pub(super) fn as_swapchain_image(&self) -> Option<&SwapchainImageBinding> {
         if let Self::SwapchainImage(binding, true) = self {
             Some(binding)
         } else if let Self::SwapchainImage(_, false) = self {
@@ -83,12 +67,9 @@ where
     }
 }
 
-impl<P> Unbind<Resolver<P>, SwapchainImage<P>> for SwapchainImageNode<P>
-where
-    P: SharedPointerKind + Send,
-{
+impl Unbind<Resolver, SwapchainImage> for SwapchainImageNode {
     // We allow the resolver to unbind a swapchain node directly into a shared image
-    fn unbind(self, graph: &mut Resolver<P>) -> SwapchainImage<P> {
+    fn unbind(self, graph: &mut Resolver) -> SwapchainImage {
         graph.graph.bindings[self.idx]
             .as_swapchain_image()
             .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-// HACK: I'm having trouble supressing the lint at src/graph/mod.rs:650
-#![allow(clippy::match_ref_pats)]
+// // HACK: I'm having trouble supressing the lint at src/graph/mod.rs:650
+// #![allow(clippy::match_ref_pats)]
 
 pub mod driver;
 pub mod graph;
@@ -11,20 +11,23 @@ mod frame;
 mod hash_pool;
 mod input;
 
-pub use self::{
-    display::{Display, DisplayError},
-    event_loop::{run, EventLoop, EventLoopBuilder, FullscreenMode},
-    frame::FrameContext,
-    hash_pool::{HashPool, Lease},
-};
-
 /// Things which are used in almost every single _Screen 13_ program.
 pub mod prelude {
     pub use {
         super::{
+            display::{Display, DisplayError},
+            driver::*,
             event_loop::{run, EventLoop, EventLoopBuilder, FullscreenMode},
             frame::{center_cursor, set_cursor_position, FrameContext},
-            graph::RenderGraph,
+            graph::{
+                AccelerationStructureBinding, AccelerationStructureLeaseBinding,
+                AccelerationStructureLeaseNode, AccelerationStructureNode,
+                AnyAccelerationStructureNode, AnyBufferBinding, AnyBufferNode, AnyImageBinding,
+                AnyImageNode, Bind, BufferBinding, BufferLeaseBinding, BufferLeaseNode, BufferNode,
+                ImageBinding, ImageLeaseBinding, ImageLeaseNode, ImageNode, PassRef,
+                PipelinePassRef, RenderGraph, SwapchainImageNode,
+            },
+            hash_pool::HashPool,
             input::{
                 update_input, update_keyboard, update_mouse, KeyBuf, KeyMap, MouseBuf, MouseButton,
             },
@@ -39,94 +42,4 @@ pub mod prelude {
     };
 }
 
-/// Like [`prelude`], but contains all public exports.
-///
-/// Use this module for access to all _Screen 13_ resources from either [`std::sync::Arc`] or
-/// [`std::rc::Rc`]-backed instances.
-pub mod prelude_all {
-    pub use super::{
-        driver::*,
-        graph::{
-            AccelerationStructureBinding, AccelerationStructureLeaseBinding,
-            AccelerationStructureLeaseNode, AccelerationStructureNode,
-            AnyAccelerationStructureNode, AnyBufferBinding, AnyBufferNode, AnyImageBinding,
-            AnyImageNode, BufferBinding, BufferLeaseBinding, BufferLeaseNode, BufferNode,
-            ImageBinding, ImageLeaseBinding, ImageLeaseNode, ImageNode, PassRef, PipelinePassRef,
-            RenderGraph, SwapchainImageNode,
-        },
-        prelude::*,
-        Display, DisplayError, HashPool, Lease,
-    }; // TODO: Expand!
-}
-
-/// Like [`prelude_all`], but specialized for [`std::sync::Arc`]-backed use cases.
-///
-/// Use this module if rendering will be done from multiple threads. See the main documentation for
-/// each alias for more information.
-pub mod prelude_arc {
-    pub use super::prelude_all::{self as all, *};
-
-    use archery::ArcK as P;
-
-    pub type AccelerationStructure = all::AccelerationStructure<P>;
-    pub type AnyBufferBinding<'a> = all::AnyBufferBinding<'a, P>;
-    pub type AnyBufferNode = all::AnyBufferNode<P>;
-    pub type AnyImageBinding<'a> = all::AnyImageBinding<'a, P>;
-    pub type AnyImageNode = all::AnyImageNode<P>;
-    pub type Buffer = all::Buffer<P>;
-    pub type BufferBinding = all::BufferBinding<P>;
-    pub type BufferLeaseNode = all::BufferLeaseNode<P>;
-    pub type BufferNode = all::BufferNode<P>;
-    pub type ComputePipeline = all::ComputePipeline<P>;
-    pub type Device = all::Device<P>;
-    pub type EventLoop = all::EventLoop<P>;
-    pub type FrameContext<'a> = all::FrameContext<'a, P>;
-    pub type GraphicPipeline = all::GraphicPipeline<P>;
-    pub type HashPool = all::HashPool<P>;
-    pub type Image = all::Image<P>;
-    pub type ImageBinding = all::ImageBinding<P>;
-    pub type ImageNode = all::ImageNode<P>;
-    pub type PipelinePassRef<'a, T> = all::PipelinePassRef<'a, T, P>;
-    pub type RayTracePipeline = all::RayTracePipeline<P>;
-    pub type RenderGraph = all::RenderGraph<P>;
-    pub type SwapchainImage = all::SwapchainImage<P>;
-
-    pub type Lease<T> = all::Lease<T, P>;
-    pub type Shared<T> = archery::SharedPointer<T, P>;
-}
-
-/// Like [`prelude_all`], but specialized for [`std::rc::Rc`]-backed use cases.
-///
-/// Use this module if rendering will be done from one thread only. See the main documentation for
-/// each alias for more information.
-pub mod prelude_rc {
-    pub use super::prelude_all::{self as all, *};
-
-    use archery::RcK as P;
-
-    pub type AccelerationStructure = all::AccelerationStructure<P>;
-    pub type AnyBufferBinding<'a> = all::AnyBufferBinding<'a, P>;
-    pub type AnyBufferNode = all::AnyBufferNode<P>;
-    pub type AnyImageBinding<'a> = all::AnyImageBinding<'a, P>;
-    pub type AnyImageNode = all::AnyImageNode<P>;
-    pub type Buffer = all::Buffer<P>;
-    pub type BufferBinding = all::BufferBinding<P>;
-    pub type BufferLeaseNode = all::BufferLeaseNode<P>;
-    pub type BufferNode = all::BufferNode<P>;
-    pub type ComputePipeline = all::ComputePipeline<P>;
-    pub type Device = all::Device<P>;
-    pub type EventLoop = all::EventLoop<P>;
-    pub type FrameContext<'a> = all::FrameContext<'a, P>;
-    pub type GraphicPipeline = all::GraphicPipeline<P>;
-    pub type HashPool = all::HashPool<P>;
-    pub type Image = all::Image<P>;
-    pub type ImageBinding = all::ImageBinding<P>;
-    pub type ImageNode = all::ImageNode<P>;
-    pub type PipelinePassRef<'a, T> = all::PipelinePassRef<'a, T, P>;
-    pub type RayTracePipeline = all::RayTracePipeline<P>;
-    pub type RenderGraph = all::RenderGraph<P>;
-    pub type SwapchainImage = all::SwapchainImage<P>;
-
-    pub type Lease<T> = all::Lease<T, P>;
-    pub type Shared<T> = archery::SharedPointer<T, P>;
-}
+pub use self::display::{Display, DisplayError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-// // HACK: I'm having trouble supressing the lint at src/graph/mod.rs:650
-// #![allow(clippy::match_ref_pats)]
+// HACK: I'm having trouble supressing the lint at src/graph/mod.rs:650
+#![allow(clippy::match_ref_pats)]
 
 pub mod driver;
 pub mod graph;
@@ -42,4 +42,14 @@ pub mod prelude {
     };
 }
 
-pub use self::display::{Display, DisplayError};
+#[deprecated]
+pub mod prelude_arc {
+    pub use super::prelude::*;
+}
+
+pub use self::{
+    display::{Display, DisplayError},
+    event_loop::{run, EventLoop, EventLoopBuilder, FullscreenMode},
+    frame::FrameContext,
+    hash_pool::{HashPool, Lease},
+};


### PR DESCRIPTION
This change makes _Screen 13_ opinionated with regard to shared references and removes support for `std::rc::Rc` reference tracking.

In the future, if and when a compelling user requests such support, we could enable `Rc` references via a feature flag and still have similar support. What will be missing from that approach is the ability to create resources using `Rc`, wait on their fences, and transition them to `Arc` references for use on a different Vulkan device backed by `Arc` references. This advanced use case is IMHO not worth the contributor-inhibiting 1,800 lines of boilerplate which have been removed here.