### PR TITLE
ClearValue as rust enum.

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -301,17 +301,13 @@ enum ClearValue {
     DepthStencil(vk::ClearDepthStencilValue),
 }
 
-impl From<ClearValue> for vk::ClearValue{
+impl From<ClearValue> for vk::ClearValue {
     fn from(src: ClearValue) -> Self {
-        match src{
-            ClearValue::Color(color) => vk::ClearValue{
-                color: vk::ClearColorValue{
-                    float32: color.0,
-                },
+        match src {
+            ClearValue::Color(color) => vk::ClearValue {
+                color: vk::ClearColorValue { float32: color.0 },
             },
-            ClearValue::DepthStencil(depth_stencil) => vk::ClearValue{
-                depth_stencil,
-            }
+            ClearValue::DepthStencil(depth_stencil) => vk::ClearValue { depth_stencil },
         }
     }
 }
@@ -321,7 +317,6 @@ struct Execution {
     accesses: BTreeMap<NodeIndex, [SubresourceAccess; 2]>,
     bindings: BTreeMap<Descriptor, (NodeIndex, Option<ViewType>)>,
 
-    //clears: BTreeMap<AttachmentIndex, vk::ClearValue>,
     clears: BTreeMap<AttachmentIndex, ClearValue>,
     loads: AttachmentMap,
     resolves: AttachmentMap,

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -360,7 +360,17 @@ impl Execution {
 
 impl Debug for Execution {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str("Execution")
+        // The only field missing is func which cannot easily be implemented because it is a
+        // FnOnce.
+        f.debug_struct("Execution")
+            .field("accesses", &self.accesses)
+            .field("bindings", &self.bindings)
+            .field("clears", &self.clears)
+            .field("loads", &self.loads)
+            .field("resolves", &self.resolves)
+            .field("stores", &self.stores)
+            .field("pipeline", &self.pipeline)
+            .finish()
     }
 }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -212,6 +212,7 @@ impl AttachmentMap {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 pub struct Color(pub [f32; 4]);
 
 impl From<[f32; 4]> for Color {
@@ -294,12 +295,34 @@ impl From<(DescriptorSetIndex, BindingIndex, [BindingOffset; 1])> for Descriptor
     }
 }
 
+#[derive(Copy, Clone, Debug)]
+enum ClearValue {
+    Color(Color),
+    DepthStencil(vk::ClearDepthStencilValue),
+}
+
+impl From<ClearValue> for vk::ClearValue{
+    fn from(src: ClearValue) -> Self {
+        match src{
+            ClearValue::Color(color) => vk::ClearValue{
+                color: vk::ClearColorValue{
+                    float32: color.0,
+                },
+            },
+            ClearValue::DepthStencil(depth_stencil) => vk::ClearValue{
+                depth_stencil,
+            }
+        }
+    }
+}
+
 #[derive(Default)]
 struct Execution {
     accesses: BTreeMap<NodeIndex, [SubresourceAccess; 2]>,
     bindings: BTreeMap<Descriptor, (NodeIndex, Option<ViewType>)>,
 
-    clears: BTreeMap<AttachmentIndex, vk::ClearValue>,
+    //clears: BTreeMap<AttachmentIndex, vk::ClearValue>,
+    clears: BTreeMap<AttachmentIndex, ClearValue>,
     loads: AttachmentMap,
     resolves: AttachmentMap,
     stores: AttachmentMap,

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -336,6 +336,7 @@ impl View for SwapchainImageNode {
     type Subresource = ImageSubresource;
 }
 
+#[derive(Debug)]
 pub enum ViewType {
     AccelerationStructure,
     Image(ImageViewInfo),

--- a/src/graph/pass_ref.rs
+++ b/src/graph/pass_ref.rs
@@ -2,9 +2,10 @@ use {
     super::{
         AccelerationStructureLeaseNode, AccelerationStructureNode, AnyAccelerationStructureNode,
         AnyBufferNode, AnyImageNode, Area, AttachmentIndex, Bind, Binding, BufferLeaseNode,
-        BufferNode, Color, Descriptor, Edge, Execution, ExecutionFunction, ExecutionPipeline,
-        ImageLeaseNode, ImageNode, Information, Node, NodeIndex, Pass, RenderGraph, SampleCount,
-        Subresource, SubresourceAccess, SwapchainImageNode, View, ViewType,
+        BufferNode, ClearValue, Color, Descriptor, Edge, Execution, ExecutionFunction,
+        ExecutionPipeline, ImageLeaseNode, ImageNode, Information, Node, NodeIndex, Pass,
+        RenderGraph, SampleCount, Subresource, SubresourceAccess, SwapchainImageNode, View,
+        ViewType,
     },
     crate::driver::{
         AccelerationStructure, AccelerationStructureGeometryData,
@@ -21,8 +22,6 @@ use {
     },
     vk_sync::AccessType,
 };
-
-use crate::graph::ClearValue;
 
 #[cfg(debug_assertions)]
 use super::Attachment;

--- a/src/graph/pass_ref.rs
+++ b/src/graph/pass_ref.rs
@@ -22,6 +22,8 @@ use {
     vk_sync::AccessType,
 };
 
+use crate::graph::ClearValue;
+
 #[cfg(debug_assertions)]
 use super::Attachment;
 
@@ -1311,12 +1313,7 @@ impl<'a> PipelinePassRef<'a, GraphicPipeline> {
             "cleared attachment uses subpass input"
         );
 
-        exec.clears.insert(
-            attachment,
-            vk::ClearValue {
-                color: vk::ClearColorValue { float32: color.0 },
-            },
-        );
+        exec.clears.insert(attachment, ClearValue::Color(color));
 
         self
     }
@@ -1349,12 +1346,10 @@ impl<'a> PipelinePassRef<'a, GraphicPipeline> {
 
         exec.clears.insert(
             attachment,
-            vk::ClearValue {
-                depth_stencil: vk::ClearDepthStencilValue {
-                    depth: depth_value,
-                    stencil: stencil_value,
-                },
-            },
+            ClearValue::DepthStencil(vk::ClearDepthStencilValue {
+                depth: depth_value,
+                stencil: stencil_value,
+            }),
         );
 
         self

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -283,6 +283,7 @@ impl Resolver {
                             .clears
                             .values()
                             .copied()
+                            .map(|c| c.into())
                             .chain(repeat(Default::default()))
                             .take(render_pass.info.attachments.len())
                             .collect::<Box<[_]>>(),


### PR DESCRIPTION
Since vk::ClearValue and vk::ClearColorValue are unions it is not possible to print them with debug. I added a simple enum and added Debug to Color and Execution. Since only the float32 field of the vk::ClearColorValue is used I haven't added an enum for it.