### PR TITLE
Improve resource pool/leasing API

### DIFF
--- a/contrib/screen-13-fx/src/bitmap_font.rs
+++ b/contrib/screen-13-fx/src/bitmap_font.rs
@@ -173,8 +173,8 @@ impl BitmapFont {
         let mut vertex_count = 0;
 
         {
-            let vertex_buf = &mut Buffer::mapped_slice_mut(&mut vertex_buf)
-                [0..vertex_buf_len as usize];
+            let vertex_buf =
+                &mut Buffer::mapped_slice_mut(&mut vertex_buf)[0..vertex_buf_len as usize];
 
             let mut offset = 0;
             for (data, char) in self.font.parse(text).map(|char| (char.tessellate(), char)) {

--- a/contrib/screen-13-fx/src/image_loader.rs
+++ b/contrib/screen-13-fx/src/image_loader.rs
@@ -226,7 +226,9 @@ impl ImageLoader {
 
         let image = render_graph.unbind_node(image);
 
-        render_graph.resolve().submit(&mut self.cache)?;
+        render_graph
+            .resolve()
+            .submit(&self.device.queue, &mut self.cache)?;
 
         Ok(image)
     }

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), DisplayError> {
         .build()?;
     let mut egui = Egui::new(&event_loop.device, &event_loop.window);
 
-    let mut cache = HashPool::new(&event_loop.device);
+    let mut cache = LazyPool::new(&event_loop.device);
 
     event_loop.run(|frame| {
         let img = frame.render_graph.bind_node(

--- a/examples/imgui.rs
+++ b/examples/imgui.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), DisplayError> {
     let event_loop = EventLoop::new().build()?;
     let display = ComputePresenter::new(&event_loop.device)?;
     let mut imgui = ImGui::new(&event_loop.device);
-    let mut pool = HashPool::new(&event_loop.device);
+    let mut pool = LazyPool::new(&event_loop.device);
 
     // Some example state to make the demo more interesting
     let mut value = 0;

--- a/examples/multipass.rs
+++ b/examples/multipass.rs
@@ -23,7 +23,6 @@ fn main() -> Result<(), DisplayError> {
     let draw_funky_shape_deferred = create_draw_funky_shape_deferred_pipeline(&event_loop.device);
 
     // We also need a cache (this one is backed by a hashmap of resource info, fast but basic)
-    // There will be more cache types later and traits exposed
     let mut cache = HashPool::new(&event_loop.device);
 
     // Static index/vertex data courtesy of the polyhedron-ops library

--- a/examples/ray_trace.rs
+++ b/examples/ray_trace.rs
@@ -730,7 +730,9 @@ fn main() -> anyhow::Result<()> {
                 });
         }
 
-        render_graph.resolve().submit(&mut cache)?;
+        render_graph
+            .resolve()
+            .submit(&event_loop.device.queue, &mut cache)?;
     }
 
     // ------------------------------------------------------------------------------------------ //

--- a/examples/shader-toy/src/main.rs
+++ b/examples/shader-toy/src/main.rs
@@ -51,7 +51,7 @@ fn main() -> anyhow::Result<()> {
         .build()
         .context("Event loop")?;
     let display = GraphicPresenter::new(&event_loop.device).context("Presenter")?;
-    let mut cache = HashPool::new(&event_loop.device);
+    let mut cache = LazyPool::new(&event_loop.device);
     let mut image_loader = ImageLoader::new(&event_loop.device).context("Loader")?;
 
     // Load source images: PakBuf -> BitmapBuf -> ImageBinding (here) -> ImageNode (during loop)

--- a/examples/shader-toy/src/main.rs
+++ b/examples/shader-toy/src/main.rs
@@ -159,7 +159,9 @@ fn main() -> anyhow::Result<()> {
     let mut blank_image_binding = Some(render_graph.unbind_node(blank_image));
     let mut temp_image_binding = Some(render_graph.unbind_node(temp_image));
 
-    render_graph.resolve().submit(&mut cache)?;
+    render_graph
+        .resolve()
+        .submit(&event_loop.device.queue, &mut cache)?;
 
     let started_at = Instant::now();
     let mut mouse_buf = MouseBuf::default();

--- a/src/display.rs
+++ b/src/display.rs
@@ -4,7 +4,7 @@ use {
             image_access_layout, CommandBuffer, Device, DriverError, Swapchain, SwapchainError,
         },
         graph::{RenderGraph, SwapchainImageNode},
-        hash_pool::HashPool,
+        pool::hash::HashPool,
     },
     ash::vk,
     log::trace,

--- a/src/display.rs
+++ b/src/display.rs
@@ -4,7 +4,6 @@ use {
             image_access_layout, CommandBuffer, Device, DriverError, Swapchain, SwapchainError,
         },
         graph::{RenderGraph, ResolverPool, SwapchainImageNode},
-        pool::hash::HashPool,
     },
     ash::vk,
     log::trace,

--- a/src/driver/descriptor_set.rs
+++ b/src/driver/descriptor_set.rs
@@ -1,7 +1,6 @@
 use {
     super::{DescriptorSetLayout, Device, DriverError},
     ash::vk,
-    derive_builder::Builder,
     log::{trace, warn},
     std::{ops::Deref, sync::Arc, thread::panicking},
 };
@@ -25,16 +24,52 @@ impl DescriptorPool {
                 &vk::DescriptorPoolCreateInfo::builder()
                     .flags(vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET)
                     .max_sets(info.max_sets)
-                    .pool_sizes(
-                        &info
-                            .pool_sizes
-                            .iter()
-                            .map(|pool_size| vk::DescriptorPoolSize {
-                                ty: pool_size.ty,
-                                descriptor_count: pool_size.descriptor_count,
-                            })
-                            .collect::<Box<[_]>>(),
-                    ),
+                    .pool_sizes(&[
+                        vk::DescriptorPoolSize {
+                            ty: vk::DescriptorType::ACCELERATION_STRUCTURE_KHR,
+                            descriptor_count: info.acceleration_structure_count,
+                        },
+                        vk::DescriptorPoolSize {
+                            ty: vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
+                            descriptor_count: info.combined_image_sampler_count,
+                        },
+                        vk::DescriptorPoolSize {
+                            ty: vk::DescriptorType::INPUT_ATTACHMENT,
+                            descriptor_count: info.input_attachment_count,
+                        },
+                        vk::DescriptorPoolSize {
+                            ty: vk::DescriptorType::SAMPLED_IMAGE,
+                            descriptor_count: info.sampled_image_count,
+                        },
+                        vk::DescriptorPoolSize {
+                            ty: vk::DescriptorType::STORAGE_BUFFER,
+                            descriptor_count: info.storage_buffer_count,
+                        },
+                        vk::DescriptorPoolSize {
+                            ty: vk::DescriptorType::STORAGE_BUFFER_DYNAMIC,
+                            descriptor_count: info.storage_buffer_dynamic_count,
+                        },
+                        vk::DescriptorPoolSize {
+                            ty: vk::DescriptorType::STORAGE_IMAGE,
+                            descriptor_count: info.storage_image_count,
+                        },
+                        vk::DescriptorPoolSize {
+                            ty: vk::DescriptorType::STORAGE_TEXEL_BUFFER,
+                            descriptor_count: info.storage_texel_buffer_count,
+                        },
+                        vk::DescriptorPoolSize {
+                            ty: vk::DescriptorType::UNIFORM_BUFFER,
+                            descriptor_count: info.uniform_buffer_count,
+                        },
+                        vk::DescriptorPoolSize {
+                            ty: vk::DescriptorType::UNIFORM_BUFFER_DYNAMIC,
+                            descriptor_count: info.uniform_buffer_dynamic_count,
+                        },
+                        vk::DescriptorPoolSize {
+                            ty: vk::DescriptorType::UNIFORM_TEXEL_BUFFER,
+                            descriptor_count: info.uniform_texel_buffer_count,
+                        },
+                    ]),
                 None,
             )
         }
@@ -121,43 +156,37 @@ impl Drop for DescriptorPool {
     }
 }
 
-#[derive(Builder, Clone, Debug, Eq, Hash, PartialEq)]
-#[builder(
-    build_fn(private, name = "fallible_build"),
-    pattern = "owned",
-    derive(Debug)
-)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct DescriptorPoolInfo {
+    pub acceleration_structure_count: u32,
+    pub combined_image_sampler_count: u32,
+    pub input_attachment_count: u32,
     pub max_sets: u32,
-    pub pool_sizes: Vec<DescriptorPoolSize>,
+    pub sampled_image_count: u32,
+    pub storage_buffer_count: u32,
+    pub storage_buffer_dynamic_count: u32,
+    pub storage_image_count: u32,
+    pub storage_texel_buffer_count: u32,
+    pub uniform_buffer_count: u32,
+    pub uniform_buffer_dynamic_count: u32,
+    pub uniform_texel_buffer_count: u32,
 }
 
 impl DescriptorPoolInfo {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(max_sets: u32) -> DescriptorPoolInfoBuilder {
-        DescriptorPoolInfoBuilder::default().max_sets(max_sets)
+    pub fn is_empty(&self) -> bool {
+        self.acceleration_structure_count
+            + self.combined_image_sampler_count
+            + self.input_attachment_count
+            + self.sampled_image_count
+            + self.storage_buffer_count
+            + self.storage_buffer_dynamic_count
+            + self.storage_image_count
+            + self.storage_texel_buffer_count
+            + self.uniform_buffer_count
+            + self.uniform_buffer_dynamic_count
+            + self.uniform_texel_buffer_count
+            == 0
     }
-}
-
-// HACK: https://github.com/colin-kiegel/rust-derive-builder/issues/56
-impl DescriptorPoolInfoBuilder {
-    pub fn build(self) -> DescriptorPoolInfo {
-        self.fallible_build()
-            .expect("All required fields set at initialization")
-    }
-}
-
-impl From<DescriptorPoolInfoBuilder> for DescriptorPoolInfo {
-    fn from(info: DescriptorPoolInfoBuilder) -> Self {
-        info.build()
-    }
-}
-
-#[derive(Builder, Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[builder(pattern = "owned")]
-pub struct DescriptorPoolSize {
-    pub ty: vk::DescriptorType,
-    pub descriptor_count: u32,
 }
 
 #[derive(Debug)]

--- a/src/driver/descriptor_set.rs
+++ b/src/driver/descriptor_set.rs
@@ -122,7 +122,11 @@ impl Drop for DescriptorPool {
 }
 
 #[derive(Builder, Clone, Debug, Eq, Hash, PartialEq)]
-#[builder(pattern = "owned", derive(Debug))]
+#[builder(
+    build_fn(private, name = "fallible_build"),
+    pattern = "owned",
+    derive(Debug)
+)]
 pub struct DescriptorPoolInfo {
     pub max_sets: u32,
     pub pool_sizes: Vec<DescriptorPoolSize>,
@@ -135,9 +139,17 @@ impl DescriptorPoolInfo {
     }
 }
 
+// HACK: https://github.com/colin-kiegel/rust-derive-builder/issues/56
+impl DescriptorPoolInfoBuilder {
+    pub fn build(self) -> DescriptorPoolInfo {
+        self.fallible_build()
+            .expect("All required fields set at initialization")
+    }
+}
+
 impl From<DescriptorPoolInfoBuilder> for DescriptorPoolInfo {
     fn from(info: DescriptorPoolInfoBuilder) -> Self {
-        info.build().unwrap()
+        info.build()
     }
 }
 

--- a/src/driver/device.rs
+++ b/src/driver/device.rs
@@ -1,8 +1,8 @@
 use {
     super::{
         DriverConfig, DriverError, Instance, PhysicalDevice,
-        PhysicalDeviceDescriptorIndexingFeatures, PhysicalDeviceRayTracePipelineProperties,
-        QueueFamily, SamplerDesc, Surface,
+        PhysicalDeviceDescriptorIndexingFeatures, PhysicalDeviceRayTracePipelineProperties, Queue,
+        SamplerDesc, Surface,
     },
     ash::{extensions::khr, vk},
     gpu_allocator::{
@@ -573,18 +573,5 @@ impl FeatureFlags {
         }
 
         res.iter().map(|name| name.as_ptr()).collect()
-    }
-}
-
-pub struct Queue {
-    queue: vk::Queue,
-    pub family: QueueFamily,
-}
-
-impl Deref for Queue {
-    type Target = vk::Queue;
-
-    fn deref(&self) -> &Self::Target {
-        &self.queue
     }
 }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -26,10 +26,7 @@ pub use {
         buffer::{Buffer, BufferInfo, BufferInfoBuilder, BufferSubresource},
         cmd_buf::CommandBuffer,
         compute::{ComputePipeline, ComputePipelineInfo, ComputePipelineInfoBuilder},
-        descriptor_set::{
-            DescriptorPool, DescriptorPoolInfo, DescriptorPoolInfoBuilder, DescriptorPoolSize,
-            DescriptorSet,
-        },
+        descriptor_set::{DescriptorPool, DescriptorPoolInfo, DescriptorSet},
         descriptor_set_layout::DescriptorSetLayout,
         device::{Device, FeatureFlags},
         graphic::{

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -72,7 +72,7 @@ use {
         error::Error,
         ffi::CStr,
         fmt::{Display, Formatter},
-        ops::Range,
+        ops::{Deref, Range},
         os::raw::c_char,
         sync::Arc,
     },
@@ -799,6 +799,19 @@ impl From<vk::PhysicalDeviceRayTracingPipelinePropertiesKHR>
             shader_group_handle_alignment: props.shader_group_handle_alignment,
             max_ray_hit_attribute_size: props.max_ray_hit_attribute_size,
         }
+    }
+}
+
+pub struct Queue {
+    queue: vk::Queue,
+    pub family: QueueFamily,
+}
+
+impl Deref for Queue {
+    type Target = vk::Queue;
+
+    fn deref(&self) -> &Self::Target {
+        &self.queue
     }
 }
 

--- a/src/driver/render_pass.rs
+++ b/src/driver/render_pass.rs
@@ -106,7 +106,11 @@ struct GraphicPipelineKey {
 }
 
 #[derive(Builder, Clone, Debug, Default, Eq, Hash, PartialEq)]
-#[builder(pattern = "owned", derive(Debug))]
+#[builder(
+    build_fn(private, name = "fallible_build"),
+    pattern = "owned",
+    derive(Debug)
+)]
 pub struct RenderPassInfo {
     pub attachments: Vec<AttachmentInfo>,
     pub subpasses: Vec<SubpassInfo>,
@@ -115,8 +119,24 @@ pub struct RenderPassInfo {
 
 impl RenderPassInfo {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new() -> RenderPassInfoBuilder {
-        Default::default()
+    pub fn new(
+        attachments: Vec<AttachmentInfo>,
+        subpasses: Vec<SubpassInfo>,
+        dependencies: Vec<SubpassDependency>,
+    ) -> RenderPassInfoBuilder {
+        RenderPassInfoBuilder {
+            attachments: Some(attachments),
+            subpasses: Some(subpasses),
+            dependencies: Some(dependencies),
+        }
+    }
+}
+
+// HACK: https://github.com/colin-kiegel/rust-derive-builder/issues/56
+impl RenderPassInfoBuilder {
+    pub fn build(self) -> RenderPassInfo {
+        self.fallible_build()
+            .expect("All required fields set at initialization")
     }
 }
 

--- a/src/graph/binding.rs
+++ b/src/graph/binding.rs
@@ -5,7 +5,7 @@ use {
     },
     crate::{
         driver::{AccelerationStructure, Buffer, Image, SwapchainImage},
-        hash_pool::Lease,
+        pool::Lease,
     },
     std::{fmt::Debug, sync::Arc},
 };

--- a/src/graph/edge.rs
+++ b/src/graph/edge.rs
@@ -9,7 +9,7 @@ use {
             AccelerationStructure, Buffer, ComputePipeline, GraphicPipeline, Image,
             RayTracePipeline, SwapchainImage,
         },
-        hash_pool::Lease,
+        pool::Lease,
     },
     std::sync::Arc,
 };

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -15,7 +15,7 @@ pub use {
             ImageLeaseNode, ImageNode, SwapchainImageNode, Unbind, View, ViewType,
         },
         pass_ref::{Bindings, Compute, Draw, PassRef, PipelinePassRef, RayTrace},
-        resolver::Resolver,
+        resolver::{Resolver, ResolverPool},
     },
     vk_sync::AccessType,
 };

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -5,7 +5,7 @@ use {
             vk, AccelerationStructure, AccelerationStructureInfo, Buffer, BufferInfo,
             BufferSubresource, Image, ImageInfo, ImageSubresource, ImageViewInfo,
         },
-        hash_pool::Lease,
+        pool::Lease,
     },
     std::{ops::Range, sync::Arc},
 };

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -12,7 +12,7 @@ use {
             DriverError, FramebufferKey, FramebufferKeyAttachment, Image, ImageViewInfo,
             RenderPass, RenderPassInfo, SampleCount, SubpassDependency, SubpassInfo,
         },
-        hash_pool::{HashPool, Lease},
+        pool::{hash::HashPool, Lease},
     },
     ash::vk,
     log::{debug, trace},

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -12,7 +12,7 @@ use {
             FramebufferKeyAttachment, Image, ImageViewInfo, Queue, QueueFamily, RenderPass,
             RenderPassInfo, SampleCount, SubpassDependency, SubpassInfo,
         },
-        pool::{hash::HashPool, Lease, Pool},
+        pool::{hash::HashPool, lazy::LazyPool, Lease, Pool},
     },
     ash::vk,
     log::{debug, trace},
@@ -502,29 +502,42 @@ impl Resolver {
                 for (descriptor_ty, descriptor_count) in pool_size {
                     debug_assert_ne!(*descriptor_count, 0);
 
-                    let info_descriptor_count = &mut match *descriptor_ty {
+                    match *descriptor_ty {
                         vk::DescriptorType::ACCELERATION_STRUCTURE_KHR => {
-                            info.acceleration_structure_count
+                            info.acceleration_structure_count += descriptor_count;
                         }
                         vk::DescriptorType::COMBINED_IMAGE_SAMPLER => {
-                            info.combined_image_sampler_count
+                            info.combined_image_sampler_count += descriptor_count;
                         }
-                        vk::DescriptorType::INPUT_ATTACHMENT => info.input_attachment_count,
-                        vk::DescriptorType::SAMPLED_IMAGE => info.sampled_image_count,
-                        vk::DescriptorType::STORAGE_BUFFER => info.storage_buffer_count,
+                        vk::DescriptorType::INPUT_ATTACHMENT => {
+                            info.input_attachment_count += descriptor_count;
+                        }
+                        vk::DescriptorType::SAMPLED_IMAGE => {
+                            info.sampled_image_count += descriptor_count;
+                        }
+                        vk::DescriptorType::STORAGE_BUFFER => {
+                            info.storage_buffer_count += descriptor_count;
+                        }
                         vk::DescriptorType::STORAGE_BUFFER_DYNAMIC => {
-                            info.storage_buffer_dynamic_count
+                            info.storage_buffer_dynamic_count += descriptor_count;
                         }
-                        vk::DescriptorType::STORAGE_IMAGE => info.storage_image_count,
-                        vk::DescriptorType::STORAGE_TEXEL_BUFFER => info.storage_texel_buffer_count,
-                        vk::DescriptorType::UNIFORM_BUFFER => info.uniform_buffer_count,
+                        vk::DescriptorType::STORAGE_IMAGE => {
+                            info.storage_image_count += descriptor_count;
+                        }
+                        vk::DescriptorType::STORAGE_TEXEL_BUFFER => {
+                            info.storage_texel_buffer_count += descriptor_count;
+                        }
+                        vk::DescriptorType::UNIFORM_BUFFER => {
+                            info.uniform_buffer_count += descriptor_count;
+                        }
                         vk::DescriptorType::UNIFORM_BUFFER_DYNAMIC => {
-                            info.uniform_buffer_dynamic_count
+                            info.uniform_buffer_dynamic_count += descriptor_count;
                         }
-                        vk::DescriptorType::UNIFORM_TEXEL_BUFFER => info.uniform_texel_buffer_count,
+                        vk::DescriptorType::UNIFORM_TEXEL_BUFFER => {
+                            info.uniform_texel_buffer_count += descriptor_count;
+                        }
                         _ => unimplemented!(),
                     };
-                    *info_descriptor_count += descriptor_count;
                 }
             }
         }
@@ -2456,3 +2469,5 @@ pub trait ResolverPool:
 }
 
 impl ResolverPool for HashPool {}
+
+impl ResolverPool for LazyPool {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,12 @@
 
 pub mod driver;
 pub mod graph;
+pub mod pool;
 
 mod device_api;
 mod display;
 mod event_loop;
 mod frame;
-mod hash_pool;
 mod input;
 
 /// Things which are used in almost every single _Screen 13_ program.
@@ -25,10 +25,10 @@ pub mod prelude {
                 AnyImageNode, Bind, BufferLeaseNode, BufferNode, ImageLeaseNode, ImageNode,
                 PassRef, PipelinePassRef, RenderGraph, SwapchainImageNode,
             },
-            hash_pool::{HashPool, Lease},
             input::{
                 update_input, update_keyboard, update_mouse, KeyBuf, KeyMap, MouseBuf, MouseButton,
             },
+            pool::{hash::HashPool, Lease},
         },
         log::{debug, error, info, logger, trace, warn}, // Everyone wants a log
         winit::{
@@ -49,5 +49,4 @@ pub use self::{
     display::{Display, DisplayError},
     event_loop::{run, EventLoop, EventLoopBuilder, FullscreenMode},
     frame::FrameContext,
-    hash_pool::{HashPool, Lease},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub mod prelude {
             input::{
                 update_input, update_keyboard, update_mouse, KeyBuf, KeyMap, MouseBuf, MouseButton,
             },
-            pool::{hash::HashPool, Lease, Pool},
+            pool::{hash::HashPool, lazy::LazyPool, Lease, Pool},
         },
         log::{debug, error, info, logger, trace, warn}, // Everyone wants a log
         winit::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub mod prelude {
             input::{
                 update_input, update_keyboard, update_mouse, KeyBuf, KeyMap, MouseBuf, MouseButton,
             },
-            pool::{hash::HashPool, Lease},
+            pool::{hash::HashPool, Lease, Pool},
         },
         log::{debug, error, info, logger, trace, warn}, // Everyone wants a log
         winit::{

--- a/src/pool/hash.rs
+++ b/src/pool/hash.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Cache, Contract, Lease},
+    super::{Cache, Contract, Lease, Pool},
     crate::driver::{
         AccelerationStructure, AccelerationStructureInfo, AccelerationStructureInfoBuilder, Buffer,
         BufferInfo, BufferInfoBuilder, CommandBuffer, DescriptorPool, DescriptorPoolInfo,
@@ -40,20 +40,30 @@ impl HashPool {
             render_pass_cache: Default::default(),
         }
     }
+}
 
-    pub fn lease<C>(&mut self, info: C) -> Result<Lease<<C as Contract>::Term>, DriverError>
-    where
-        C: Pooled<Lease<<C as Contract>::Term>>,
-        C: Contract + Debug,
-    {
-        info.lease(self)
+impl Pool<DescriptorPoolInfo, DescriptorPool> for HashPool {
+    fn lease(
+        &mut self,
+        contract: DescriptorPoolInfo,
+    ) -> Result<Lease<DescriptorPool>, DriverError> {
+        todo!();
     }
 }
 
-pub trait Pooled<T> {
-    fn lease(self, pool: &mut HashPool) -> Result<T, DriverError>;
+impl Pool<RenderPassInfo, RenderPass> for HashPool {
+    fn lease(&mut self, contract: RenderPassInfo) -> Result<Lease<RenderPass>, DriverError> {
+        todo!();
+    }
 }
 
+impl Pool<QueueFamily, CommandBuffer> for HashPool {
+    fn lease(&mut self, contract: QueueFamily) -> Result<Lease<CommandBuffer>, DriverError> {
+        todo!();
+    }
+}
+
+/*
 // Enable the basic leasing of items
 macro_rules! lease {
     ($src:ident => $dst:ident) => {
@@ -62,7 +72,7 @@ macro_rules! lease {
         }
 
         paste::paste! {
-            impl Pooled<Lease<$dst>> for $src {
+            impl Pool<Lease<$dst>, HashPool> for $src {
                 fn lease(self, pool: &mut HashPool) -> Result<Lease<$dst>, DriverError> {
                     let cache = pool.[<$dst:snake _cache>].entry(self.clone())
                         .or_insert_with(|| {
@@ -144,7 +154,7 @@ macro_rules! lease_info_builder {
                 type Term = $dst;
             }
 
-            impl Pooled<Lease<$dst>> for [<$src Builder>] {
+            impl Pool<Lease<$dst>, HashPool> for [<$src Builder>] {
                 fn lease(self, pool: &mut HashPool) -> Result<Lease<$dst>, DriverError> {
                     let info = self.build();
 
@@ -168,7 +178,7 @@ macro_rules! lease_info_binding {
             }
 
             paste::paste! {
-                impl Pooled<Lease<$dst>> for $src {
+                impl Pool<Lease<$dst>, HashPool> for $src {
                     fn lease(self, pool: &mut HashPool) -> Result<Lease<$dst>, DriverError> {
                         let cache = pool.[<$dst:snake _cache>].entry(self.clone())
                             .or_insert_with(|| {
@@ -212,7 +222,7 @@ macro_rules! lease_info_binding {
                 type Term = $dst;
             }
 
-            impl Pooled<Lease<$dst>> for [<$src Builder>] {
+            impl Pool<Lease<$dst>, HashPool> for [<$src Builder>] {
                 fn lease(self, pool: &mut HashPool) -> Result<Lease<$dst>, DriverError> {
                     self.build().lease(pool)
                 }
@@ -225,3 +235,4 @@ lease_info_binding!(AccelerationStructureInfo => AccelerationStructure);
 lease_info_binding!(BufferInfo => Buffer);
 lease_info_binding!(ImageInfo => Image);
 lease_info_binding!(DescriptorPoolInfo => DescriptorPool);
+ */

--- a/src/pool/lazy.rs
+++ b/src/pool/lazy.rs
@@ -1,0 +1,330 @@
+use {
+    super::{Cache, Lease, Pool},
+    crate::driver::{
+        AccelerationStructure, AccelerationStructureInfo, AccelerationStructureInfoBuilder, Buffer,
+        BufferInfo, BufferInfoBuilder, CommandBuffer, DescriptorPool, DescriptorPoolInfo, Device,
+        DriverError, Image, ImageInfo, ImageInfoBuilder, ImageType, QueueFamily, RenderPass,
+        RenderPassInfo, SampleCount,
+    },
+    ash::vk,
+    parking_lot::Mutex,
+    std::{
+        collections::{HashMap, VecDeque},
+        fmt::Debug,
+        sync::Arc,
+    },
+};
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct ImageKey {
+    array_elements: u32,
+    depth: u32,
+    fmt: vk::Format,
+    height: u32,
+    linear_tiling: bool,
+    mip_level_count: u32,
+    sample_count: SampleCount,
+    ty: ImageType,
+    width: u32,
+}
+
+#[derive(Debug)]
+pub struct LazyPool {
+    acceleration_structure_cache:
+        HashMap<vk::AccelerationStructureTypeKHR, Cache<AccelerationStructure>>,
+    buffer_cache: HashMap<bool, Cache<Buffer>>,
+    command_buffer_cache: HashMap<u32, Cache<CommandBuffer>>,
+    descriptor_pool_cache: Cache<DescriptorPool>,
+    pub device: Arc<Device>,
+    image_cache: HashMap<ImageKey, Cache<Image>>,
+    render_pass_cache: HashMap<RenderPassInfo, Cache<RenderPass>>,
+}
+
+// TODO: Add some sort of manager features (like, I dunno, "Clear Some Memory For me")
+impl LazyPool {
+    pub fn new(device: &Arc<Device>) -> Self {
+        let device = Arc::clone(device);
+
+        Self {
+            acceleration_structure_cache: Default::default(),
+            buffer_cache: Default::default(),
+            command_buffer_cache: Default::default(),
+            descriptor_pool_cache: Default::default(),
+            device,
+            image_cache: Default::default(),
+            render_pass_cache: Default::default(),
+        }
+    }
+
+    fn can_lease_command_buffer(cmd_buf: &mut CommandBuffer) -> bool {
+        let can_lease = unsafe {
+            // Don't lease this command buffer if it is unsignalled; we'll create a new one
+            // and wait for this, and those behind it, to signal.
+            cmd_buf
+                .device
+                .get_fence_status(cmd_buf.fence)
+                .unwrap_or_default()
+        };
+
+        if can_lease {
+            // Drop anything we were holding from the last submission
+            CommandBuffer::drop_fenced(cmd_buf);
+        }
+
+        can_lease
+    }
+}
+
+impl Pool<AccelerationStructureInfo, AccelerationStructure> for LazyPool {
+    fn lease(
+        &mut self,
+        info: AccelerationStructureInfo,
+    ) -> Result<Lease<AccelerationStructure>, DriverError> {
+        let acceleration_structure_cache = self
+            .acceleration_structure_cache
+            .entry(info.ty)
+            .or_default();
+        let cache_ref = Arc::clone(acceleration_structure_cache);
+        let mut cache = acceleration_structure_cache.lock();
+
+        if cache.is_empty() {
+            let item = AccelerationStructure::create(&self.device, info)?;
+
+            return Ok(Lease {
+                cache: Some(cache_ref),
+                item: Some(item),
+            });
+        }
+
+        // Look for a compatible acceleration structure (big enough)
+        for idx in 0..cache.len() {
+            let item = &cache[idx];
+            if item.info.size >= info.size {
+                let item = cache.remove(idx).unwrap();
+
+                return Ok(Lease {
+                    cache: Some(cache_ref),
+                    item: Some(item),
+                });
+            }
+        }
+
+        let item = AccelerationStructure::create(&self.device, info)?;
+
+        Ok(Lease {
+            cache: Some(cache_ref),
+            item: Some(item),
+        })
+    }
+}
+
+impl Pool<AccelerationStructureInfoBuilder, AccelerationStructure> for LazyPool {
+    fn lease(
+        &mut self,
+        info: AccelerationStructureInfoBuilder,
+    ) -> Result<Lease<AccelerationStructure>, DriverError> {
+        self.lease(info.build())
+    }
+}
+
+impl Pool<BufferInfo, Buffer> for LazyPool {
+    fn lease(&mut self, info: BufferInfo) -> Result<Lease<Buffer>, DriverError> {
+        let buffer_cache = self.buffer_cache.entry(info.can_map).or_default();
+        let cache_ref = Arc::clone(buffer_cache);
+        let mut cache = buffer_cache.lock();
+
+        if cache.is_empty() {
+            let item = Buffer::create(&self.device, info)?;
+
+            return Ok(Lease {
+                cache: Some(cache_ref),
+                item: Some(item),
+            });
+        }
+
+        // Look for a compatible buffer (same mapping mode, big enough, superset of usage flags)
+        for idx in 0..cache.len() {
+            let item = &cache[idx];
+            if item.info.can_map == info.can_map
+                && item.info.size >= info.size
+                && item.info.usage.contains(info.usage)
+            {
+                let item = cache.remove(idx).unwrap();
+
+                return Ok(Lease {
+                    cache: Some(cache_ref),
+                    item: Some(item),
+                });
+            }
+        }
+
+        let item = Buffer::create(&self.device, info)?;
+
+        Ok(Lease {
+            cache: Some(cache_ref),
+            item: Some(item),
+        })
+    }
+}
+
+impl Pool<BufferInfoBuilder, Buffer> for LazyPool {
+    fn lease(&mut self, info: BufferInfoBuilder) -> Result<Lease<Buffer>, DriverError> {
+        self.lease(info.build())
+    }
+}
+
+impl Pool<DescriptorPoolInfo, DescriptorPool> for LazyPool {
+    fn lease(&mut self, info: DescriptorPoolInfo) -> Result<Lease<DescriptorPool>, DriverError> {
+        let cache_ref = Arc::clone(&self.descriptor_pool_cache);
+        let mut cache = self.descriptor_pool_cache.lock();
+
+        if cache.is_empty() {
+            let item = DescriptorPool::create(&self.device, info)?;
+
+            return Ok(Lease {
+                cache: Some(cache_ref),
+                item: Some(item),
+            });
+        }
+
+        // Look for a compatible descriptor pool (has enough sets and descriptors)
+        for idx in 0..cache.len() {
+            let item = &cache[idx];
+            if item.info.max_sets >= info.max_sets
+                && item.info.acceleration_structure_count >= info.acceleration_structure_count
+                && item.info.combined_image_sampler_count >= info.combined_image_sampler_count
+                && item.info.input_attachment_count >= info.input_attachment_count
+                && item.info.sampled_image_count >= info.sampled_image_count
+                && item.info.storage_buffer_count >= info.storage_buffer_count
+                && item.info.storage_buffer_dynamic_count >= info.storage_buffer_dynamic_count
+                && item.info.storage_image_count >= info.storage_image_count
+                && item.info.storage_texel_buffer_count >= info.storage_texel_buffer_count
+                && item.info.uniform_buffer_count >= info.uniform_buffer_count
+                && item.info.uniform_buffer_dynamic_count >= info.uniform_buffer_dynamic_count
+                && item.info.uniform_texel_buffer_count >= info.uniform_texel_buffer_count
+            {
+                let item = cache.remove(idx).unwrap();
+
+                return Ok(Lease {
+                    cache: Some(cache_ref),
+                    item: Some(item),
+                });
+            }
+        }
+
+        let item = DescriptorPool::create(&self.device, info)?;
+
+        Ok(Lease {
+            cache: Some(cache_ref),
+            item: Some(item),
+        })
+    }
+}
+
+impl Pool<ImageInfo, Image> for LazyPool {
+    fn lease(&mut self, info: ImageInfo) -> Result<Lease<Image>, DriverError> {
+        let image_cache = self
+            .image_cache
+            .entry(ImageKey {
+                array_elements: info.array_elements,
+                depth: info.depth,
+                fmt: info.fmt,
+                height: info.height,
+                linear_tiling: info.linear_tiling,
+                mip_level_count: info.mip_level_count,
+                sample_count: info.sample_count,
+                ty: info.ty,
+                width: info.width,
+            })
+            .or_default();
+        let cache_ref = Arc::clone(image_cache);
+        let mut cache = image_cache.lock();
+
+        if cache.is_empty() {
+            let item = Image::create(&self.device, info)?;
+
+            return Ok(Lease {
+                cache: Some(cache_ref),
+                item: Some(item),
+            });
+        }
+
+        // Look for a compatible image (superset of creation flags and usage flags)
+        for idx in 0..cache.len() {
+            let item = &cache[idx];
+            if item.info.flags.contains(info.flags) && item.info.usage.contains(info.usage) {
+                let item = cache.remove(idx).unwrap();
+
+                return Ok(Lease {
+                    cache: Some(cache_ref),
+                    item: Some(item),
+                });
+            }
+        }
+
+        let item = Image::create(&self.device, info)?;
+
+        Ok(Lease {
+            cache: Some(cache_ref),
+            item: Some(item),
+        })
+    }
+}
+
+impl Pool<ImageInfoBuilder, Image> for LazyPool {
+    fn lease(&mut self, info: ImageInfoBuilder) -> Result<Lease<Image>, DriverError> {
+        self.lease(info.build())
+    }
+}
+
+impl Pool<RenderPassInfo, RenderPass> for LazyPool {
+    fn lease(&mut self, info: RenderPassInfo) -> Result<Lease<RenderPass>, DriverError> {
+        if let Some(cache) = self.render_pass_cache.get(&info) {
+            let item = if let Some(item) = cache.lock().pop_front() {
+                item
+            } else {
+                RenderPass::create(&self.device, info)?
+            };
+
+            Ok(Lease {
+                cache: Some(cache.clone()),
+                item: Some(item),
+            })
+        } else {
+            let cache = Arc::new(Mutex::new(VecDeque::new()));
+            self.render_pass_cache.insert(info.clone(), cache.clone());
+
+            let item = RenderPass::create(&self.device, info)?;
+
+            Ok(Lease {
+                cache: Some(cache),
+                item: Some(item),
+            })
+        }
+    }
+}
+
+impl Pool<QueueFamily, CommandBuffer> for LazyPool {
+    fn lease(&mut self, queue_family: QueueFamily) -> Result<Lease<CommandBuffer>, DriverError> {
+        let cache = self
+            .command_buffer_cache
+            .entry(queue_family.idx)
+            .or_insert_with(|| Arc::new(Mutex::new(VecDeque::new())));
+        let cache_ref = Arc::clone(cache);
+        let mut cache = cache.lock();
+
+        if cache.is_empty() || !Self::can_lease_command_buffer(cache.front_mut().unwrap()) {
+            let item = CommandBuffer::create(&self.device, queue_family)?;
+
+            return Ok(Lease {
+                cache: Some(cache_ref),
+                item: Some(item),
+            });
+        }
+
+        Ok(Lease {
+            cache: Some(cache_ref),
+            item: cache.pop_front(),
+        })
+    }
+}

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1,6 +1,7 @@
 pub mod hash;
 
 use {
+    crate::driver::{Device, DriverError},
     log::warn,
     parking_lot::Mutex,
     std::{
@@ -69,4 +70,8 @@ impl<T> Drop for Lease<T> {
             }
         }
     }
+}
+
+pub trait Pool<Contract, T> {
+    fn lease(&mut self, contract: Contract) -> Result<Lease<T>, DriverError>;
 }

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1,4 +1,5 @@
 pub mod hash;
+pub mod lazy;
 
 use {
     crate::driver::DriverError,
@@ -23,13 +24,13 @@ pub struct Lease<T> {
 
 impl<T> AsRef<T> for Lease<T> {
     fn as_ref(&self) -> &T {
-        &*self
+        self.item.as_ref().unwrap()
     }
 }
 
 impl<T> AsMut<T> for Lease<T> {
     fn as_mut(&mut self) -> &mut T {
-        &mut *self
+        self.item.as_mut().unwrap()
     }
 }
 

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1,7 +1,7 @@
 pub mod hash;
 
 use {
-    crate::driver::{Device, DriverError},
+    crate::driver::DriverError,
     log::warn,
     parking_lot::Mutex,
     std::{
@@ -14,10 +14,6 @@ use {
 };
 
 type Cache<T> = Arc<Mutex<VecDeque<T>>>;
-
-pub trait Contract {
-    type Term;
-}
 
 #[derive(Debug)]
 pub struct Lease<T> {
@@ -72,6 +68,6 @@ impl<T> Drop for Lease<T> {
     }
 }
 
-pub trait Pool<Contract, T> {
-    fn lease(&mut self, contract: Contract) -> Result<Lease<T>, DriverError>;
+pub trait Pool<I, T> {
+    fn lease(&mut self, info: I) -> Result<Lease<T>, DriverError>;
 }

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1,0 +1,72 @@
+pub mod hash;
+
+use {
+    log::warn,
+    parking_lot::Mutex,
+    std::{
+        collections::VecDeque,
+        fmt::Debug,
+        ops::{Deref, DerefMut},
+        sync::Arc,
+        thread::panicking,
+    },
+};
+
+type Cache<T> = Arc<Mutex<VecDeque<T>>>;
+
+pub trait Contract {
+    type Term;
+}
+
+#[derive(Debug)]
+pub struct Lease<T> {
+    cache: Option<Cache<T>>,
+    item: Option<T>,
+}
+
+impl<T> AsRef<T> for Lease<T> {
+    fn as_ref(&self) -> &T {
+        &*self
+    }
+}
+
+impl<T> AsMut<T> for Lease<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut *self
+    }
+}
+
+impl<T> Deref for Lease<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.item.as_ref().unwrap()
+    }
+}
+
+impl<T> DerefMut for Lease<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.item.as_mut().unwrap()
+    }
+}
+
+impl<T> Drop for Lease<T> {
+    fn drop(&mut self) {
+        if panicking() {
+            return;
+        }
+
+        if let Some(cache) = self.cache.as_ref() {
+            let mut cache = cache.lock();
+
+            // TODO: I'm sure some better logic would be handy
+            if cache.len() < 8 {
+                cache.push_back(self.item.take().unwrap());
+            } else {
+                // TODO: Better design for this - we are dropping these extra resources to avoid
+                // bigger issues - but this is just a symptom really - hasn't been a priority yet
+                warn!("hash pool build-up");
+            }
+        }
+    }
+}

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -3,7 +3,6 @@ pub mod lazy;
 
 use {
     crate::driver::DriverError,
-    log::warn,
     parking_lot::Mutex,
     std::{
         collections::VecDeque,

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -55,16 +55,7 @@ impl<T> Drop for Lease<T> {
         }
 
         if let Some(cache) = self.cache.as_ref() {
-            let mut cache = cache.lock();
-
-            // TODO: I'm sure some better logic would be handy
-            if cache.len() < 8 {
-                cache.push_back(self.item.take().unwrap());
-            } else {
-                // TODO: Better design for this - we are dropping these extra resources to avoid
-                // bigger issues - but this is just a symptom really - hasn't been a priority yet
-                warn!("hash pool build-up");
-            }
+            cache.lock().push_back(self.item.take().unwrap());
         }
     }
 }


### PR DESCRIPTION
This change is intended to improve the usability of _Screen 13_ by letting users choose different cache strategies for different parts of their render graph. Leasing resources (automatic lifetime management) will remain the central concept but the types of leases available will be new.

Currently _Screen 13_ provides a single `HashPool` type which provides resource leases using the `PartialEq` trait. More advanced cases might use a algorithm that fits existing resources to the requests at hand - for example leasing a buffer that is larger than required but avoids constructing a new one.

**TODO**

- [x] Move the `HashPool` code into a separate module
- [x] Improve leasing traits, allow multiple types
- [x] Add basic pool containers/algorithms