### PR TITLE
Acceleration structure build dependencies test

### DIFF
--- a/contrib/screen-13-fx/src/bitmap_font.rs
+++ b/contrib/screen-13-fx/src/bitmap_font.rs
@@ -173,8 +173,8 @@ impl BitmapFont {
         let mut vertex_count = 0;
 
         {
-            let vertex_buf = &mut Buffer::mapped_slice_mut(&mut vertex_buf)
-                [0..vertex_buf_len as usize];
+            let vertex_buf =
+                &mut Buffer::mapped_slice_mut(&mut vertex_buf)[0..vertex_buf_len as usize];
 
             let mut offset = 0;
             for (data, char) in self.font.parse(text).map(|char| (char.tessellate(), char)) {

--- a/examples/fuzzer.rs
+++ b/examples/fuzzer.rs
@@ -137,12 +137,12 @@ fn record_accel_struct_builds(frame: &mut FrameContext, cache: &mut HashPool) {
             },
         }],
     };
-    let blas_size = AccelerationStructure::size_of(&frame.device, &blas_geometry_info);
+    let blas_size = AccelerationStructure::size_of(frame.device, &blas_geometry_info);
     let blas_info = AccelerationStructureInfo::new_blas(blas_size.create_size);
 
     let instance_len = size_of::<vk::AccelerationStructureInstanceKHR>() as vk::DeviceSize;
     let mut instance_buf = Buffer::create(
-        &frame.device,
+        frame.device,
         BufferInfo::new_mappable(
             instance_len * BLAS_COUNT,
             vk::BufferUsageFlags::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_KHR
@@ -205,7 +205,7 @@ fn record_accel_struct_builds(frame: &mut FrameContext, cache: &mut HashPool) {
             },
         }],
     };
-    let tlas_size = AccelerationStructure::size_of(&frame.device, &tlas_geometry_info);
+    let tlas_size = AccelerationStructure::size_of(frame.device, &tlas_geometry_info);
     let tlas = cache
         .lease(AccelerationStructureInfo {
             ty: vk::AccelerationStructureTypeKHR::TOP_LEVEL,

--- a/examples/fuzzer.rs
+++ b/examples/fuzzer.rs
@@ -45,7 +45,6 @@ fn main() -> Result<(), DisplayError> {
         // We fuzz a random amount of randomly selected operations per frame
         let operations_per_frame = 16;
         let operation: u8 = random();
-        let operation: u8 = 7;
         for _ in 0..operations_per_frame {
             match operation % 8 {
                 0 => record_compute_array_bind(&mut frame, &mut cache),
@@ -70,7 +69,7 @@ fn main() -> Result<(), DisplayError> {
 }
 
 fn record_accel_struct_builds(frame: &mut FrameContext, cache: &mut HashPool) {
-    const BLAS_COUNT: vk::DeviceSize = 64;
+    const BLAS_COUNT: vk::DeviceSize = 32;
 
     // Vertex buffer for a triangle
     let vertex_buf = {

--- a/examples/ray_trace.rs
+++ b/examples/ray_trace.rs
@@ -347,6 +347,7 @@ fn create_ray_trace_pipeline(device: &Arc<Device>) -> Result<Arc<RayTracePipelin
     )?))
 }
 
+#[allow(clippy::type_complexity)]
 fn load_scene_buffers(
     device: &Arc<Device>,
 ) -> Result<(Arc<Buffer>, Arc<Buffer>, u32, u32, Arc<Buffer>, Arc<Buffer>), DriverError> {
@@ -505,7 +506,7 @@ fn main() -> anyhow::Result<()> {
 
     let sbt_handle_size = align_up(shader_group_handle_size, shader_group_handle_alignment);
     let sbt_rgen_size = align_up(sbt_handle_size, shader_group_base_alignment);
-    let sbt_hit_size = align_up(1 * sbt_handle_size, shader_group_base_alignment);
+    let sbt_hit_size = align_up(sbt_handle_size, shader_group_base_alignment);
     let sbt_miss_size = align_up(2 * sbt_handle_size, shader_group_base_alignment);
     let sbt_buf = Arc::new({
         let mut buf = Buffer::create(
@@ -736,10 +737,10 @@ fn main() -> anyhow::Result<()> {
     let mut frame_count = 0;
     let mut image = None;
     let mut keyboard = KeyBuf::default();
-    let mut position = [1.39176035, 3.51999736, 5.59873962, 1f32];
-    let right = [0.999987483f32, 0.00000000, -0.00499906437, 1.00000000];
+    let mut position = [1.391_760_3, 3.519_997_4, 5.598_739_6, 1f32];
+    let right = [0.999_987_5_f32, 0.00000000, -0.004_999_064_4, 1.00000000];
     let up = [0f32, 1.0, 0.0, 1.0];
-    let forward = [-0.00499906437f32, 0.00000000, -0.999987483, 1.00000000];
+    let forward = [-0.004_999_064_4_f32, 0.00000000, -0.999_987_5, 1.00000000];
 
     // The event loop consists of:
     // - Lazy-init the storage image used to accumulate light

--- a/src/display.rs
+++ b/src/display.rs
@@ -208,10 +208,6 @@ impl Display {
 
         self.swapchain.present_image(swapchain_image);
 
-        // Store the resolved graph because it contains bindings, leases, and other shared resources
-        // that need to be kept alive until the fence is waited upon.
-        CommandBuffer::push_fenced_drop(&mut self.cmd_bufs[swapchain_image_idx][2], resolver);
-
         Ok(())
     }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -208,6 +208,10 @@ impl Display {
 
         self.swapchain.present_image(swapchain_image);
 
+        // Store the resolved graph because it contains bindings, leases, and other shared resources
+        // that need to be kept alive until the fence is waited upon.
+        CommandBuffer::push_fenced_drop(&mut self.cmd_bufs[swapchain_image_idx][2], resolver);
+
         Ok(())
     }
 

--- a/src/driver/device.rs
+++ b/src/driver/device.rs
@@ -9,7 +9,7 @@ use {
         vulkan::{Allocator, AllocatorCreateDesc},
         AllocatorDebugSettings,
     },
-    log::{debug, info, trace, warn},
+    log::{debug, error, info, trace, warn},
     parking_lot::Mutex,
     std::{
         collections::{HashMap, HashSet},
@@ -465,7 +465,11 @@ impl Device {
         unsafe {
             match this.device.wait_for_fences(fences, true, 100) {
                 Ok(_) => return Ok(()),
-                Err(err) if err == vk::Result::ERROR_DEVICE_LOST => (),
+                Err(err) if err == vk::Result::ERROR_DEVICE_LOST => {
+                    error!("Device lost");
+
+                    return Err(DriverError::InvalidData);
+                }
                 Err(err) if err == vk::Result::TIMEOUT => {
                     trace!("waiting...");
                 }
@@ -476,7 +480,11 @@ impl Device {
 
             match this.device.wait_for_fences(fences, true, u64::MAX) {
                 Ok(_) => (),
-                Err(err) if err == vk::Result::ERROR_DEVICE_LOST => (),
+                Err(err) if err == vk::Result::ERROR_DEVICE_LOST => {
+                    error!("Device lost");
+
+                    return Err(DriverError::InvalidData);
+                }
                 _ => return Err(DriverError::OutOfMemory),
             }
 

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -22,7 +22,6 @@ use {
         iter::repeat,
         mem::take,
         ops::Range,
-        sync::Arc,
     },
     vk_sync::{cmd::pipeline_barrier, AccessType, BufferBarrier, GlobalBarrier, ImageBarrier},
 };
@@ -379,22 +378,13 @@ impl Resolver {
         let physical_pass = &self.physical_passes[pass_idx];
         let pipeline_bind_point = pipeline.bind_point();
         let pipeline = match pipeline {
-            ExecutionPipeline::Compute(pipeline) => {
-                CommandBuffer::push_fenced_drop(cmd_buf, Arc::clone(pipeline));
-                ***pipeline
-            }
-            ExecutionPipeline::Graphic(pipeline) => {
-                CommandBuffer::push_fenced_drop(cmd_buf, Arc::clone(pipeline));
-                physical_pass
-                    .render_pass
-                    .as_ref()
-                    .unwrap()
-                    .graphic_pipeline_ref(pipeline, depth_stencil, exec_idx as _)?
-            }
-            ExecutionPipeline::RayTrace(pipeline) => {
-                CommandBuffer::push_fenced_drop(cmd_buf, Arc::clone(pipeline));
-                ***pipeline
-            }
+            ExecutionPipeline::Compute(pipeline) => ***pipeline,
+            ExecutionPipeline::Graphic(pipeline) => physical_pass
+                .render_pass
+                .as_ref()
+                .unwrap()
+                .graphic_pipeline_ref(pipeline, depth_stencil, exec_idx as _)?,
+            ExecutionPipeline::RayTrace(pipeline) => ***pipeline,
         };
 
         unsafe {

--- a/src/input/typing.rs
+++ b/src/input/typing.rs
@@ -1,6 +1,6 @@
 use {super::KeyBuf, winit::event::VirtualKeyCode};
 
-#[derive(Default, PartialEq)]
+#[derive(Default, Eq, PartialEq)]
 pub struct Typing {
     buf: String,
     pos: usize,


### PR DESCRIPTION
Adds a fuzzer test which demonstrates one correct way of generating a bunch of bottom-level acceleration structures in a frame and building their top-level acceleration structure later in the same frame.