### PR TITLE
Fix for accessing destroyed swapchain

### DIFF
--- a/src/driver/swapchain.rs
+++ b/src/driver/swapchain.rs
@@ -129,7 +129,7 @@ impl Swapchain {
         }
     }
 
-    fn destroy(&self) {
+    fn destroy(&mut self) {
         if self.swapchain != vk::SwapchainKHR::null() {
             unsafe {
                 self.device
@@ -138,6 +138,8 @@ impl Swapchain {
                     .unwrap()
                     .destroy_swapchain(self.swapchain, None);
             }
+
+            self.swapchain = vk::SwapchainKHR::null();
         }
     }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -125,7 +125,12 @@ impl EventLoop {
                 dt_filtered = dt_filtered + (dt_raw - dt_filtered) / 10.0;
             };
 
-            let (swapchain, mut render_graph) = self.display.acquire_next_image()?;
+            let swapchain = self.display.acquire_next_image();
+            if swapchain.is_err() {
+                continue;
+            }
+
+            let (swapchain, mut render_graph) = swapchain.unwrap();
 
             frame_fn(FrameContext {
                 device: &self.device,

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -127,6 +127,8 @@ impl EventLoop {
 
             let swapchain = self.display.acquire_next_image();
             if swapchain.is_err() {
+                events.clear();
+
                 continue;
             }
 


### PR DESCRIPTION
Fixes #35

The `swapchain` handle was kept after destroy, and later used as part of the recreate function.

TODO:
- [x] Fix for events which "build up" during the time a window is minimized: flush them or filter out good things?
- [x] Check [kajiya](https://github.com/EmbarkStudios/kajiya) and other `ash`-based engines to see if similar bugs could exist and be fixed