### PR TITLE
Add `VK_NULL_HANDLE` vertex buffer binding support

### DIFF
--- a/src/driver/device.rs
+++ b/src/driver/device.rs
@@ -159,6 +159,7 @@ impl Device {
             vk::PhysicalDeviceBufferDeviceAddressFeatures::builder();
         let mut descriptor_indexing_features =
             vk::PhysicalDeviceDescriptorIndexingFeatures::builder();
+        let mut robustness2_features = vk::PhysicalDeviceRobustness2FeaturesEXT::builder();
 
         #[cfg(not(target_os = "macos"))]
         let mut separate_depth_stencil_layouts_features =
@@ -180,7 +181,8 @@ impl Device {
             let mut features2 = vk::PhysicalDeviceFeatures2::builder()
                 .push_next(&mut buffer_device_address_features)
                 .push_next(&mut descriptor_indexing_features)
-                .push_next(&mut imageless_framebuffer_features);
+                .push_next(&mut imageless_framebuffer_features)
+                .push_next(&mut robustness2_features);
 
             #[cfg(not(target_os = "macos"))]
             {
@@ -585,6 +587,8 @@ impl FeatureFlags {
         if self.presentation {
             res.push(khr::Swapchain::name());
         }
+
+        //res.push(vk::ExtRobustness2Fn::name());
 
         if self.ray_tracing {
             res.extend(

--- a/src/graph/pass_ref.rs
+++ b/src/graph/pass_ref.rs
@@ -1092,6 +1092,24 @@ impl<'a> Draw<'a> {
         self
     }
 
+    /// TEMPORARY
+    pub fn bind_null_vertex_buffer(
+        &self,
+    ) -> &Self {
+        use std::slice::from_ref;
+
+        unsafe {
+            self.device.cmd_bind_vertex_buffers(
+                self.cmd_buf,
+                0,
+                from_ref(&vk::Buffer::null()),
+                from_ref(&0),
+            );
+        }
+
+        self
+    }
+
     /// Binds multiple vertex buffers to the current pass, starting at the given `first_binding`.
     ///
     /// Each vertex input binding in `buffers` specifies an offset from the start of the


### PR DESCRIPTION
This change enables `VK_EXT_robustness2` features so that `VK_NULL_HANDLE` may be bound to a vertex buffer binding in order to render with just an index buffer. See #41

The first commit of this change adds a draft function for testing, `bind_null_vertex_buffer`. This function will very likely be replaced with something nicer before merge.

TODO:
- [x] Test using `fuzzer.rs`
- [ ] Expand `AnyBufferBinding` or make a similar `enum` for these cases
- [ ] Gracefully handle unavailable features (test on such hardware)