### PR TITLE
Fix: Attempted write update to an immutable sampler descriptor.

### DIFF
--- a/src/driver/graphic.rs
+++ b/src/driver/graphic.rs
@@ -5,11 +5,8 @@ use {
         device::Device,
         image::SampleCount,
         merge_push_constant_ranges,
-        shader::{
-            DescriptorBindingMap, DescriptorInfo, PipelineDescriptorInfo, Shader,
-            SpecializationInfo,
-        },
-        DescriptorBinding, DriverError,
+        shader::{DescriptorBindingMap, PipelineDescriptorInfo, Shader, SpecializationInfo},
+        DriverError,
     },
     ash::vk,
     derive_builder::{Builder, UninitializedFieldError},
@@ -366,7 +363,6 @@ pub struct GraphicPipeline {
     pub name: Option<String>,
 
     pub(crate) push_constants: Vec<vk::PushConstantRange>,
-    pub(crate) separate_samplers: Box<[DescriptorBinding]>,
     pub(crate) shader_modules: Vec<vk::ShaderModule>,
     pub(super) state: GraphicPipelineState,
 }
@@ -462,13 +458,6 @@ impl GraphicPipeline {
                 descriptor_info.set_binding_count(info.bindless_descriptor_count);
             }
         }
-
-        let separate_samplers = descriptor_bindings
-            .iter()
-            .filter_map(|(&descriptor_binding, (descriptor_info, _))| {
-                matches!(descriptor_info, DescriptorInfo::Sampler(..)).then_some(descriptor_binding)
-            })
-            .collect();
 
         let descriptor_info = PipelineDescriptorInfo::create(&device, &descriptor_bindings)?;
         let descriptor_sets_layouts = descriptor_info
@@ -571,7 +560,6 @@ impl GraphicPipeline {
                 layout,
                 name: None,
                 push_constants,
-                separate_samplers,
                 shader_modules,
                 state: GraphicPipelineState {
                     layout,

--- a/src/driver/shader.rs
+++ b/src/driver/shader.rs
@@ -144,7 +144,7 @@ impl DescriptorInfo {
         }
     }
 
-    pub fn sampler(&self) -> Option<&Sampler> {
+    fn sampler(&self) -> Option<&Sampler> {
         match self {
             Self::CombinedImageSampler(_, sampler, _) | Self::Sampler(_, sampler, _) => {
                 Some(sampler)

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -2846,7 +2846,6 @@ impl Resolver {
                             image_view_info.aspect_mask = format_aspect_mask(image.info.fmt);
                         }
 
-                        let sampler = descriptor_info.sampler().map(|sampler| **sampler).unwrap_or_default();
                         let image_view = Image::view(image, image_view_info)?;
                         let image_layout = match descriptor_type {
                             vk::DescriptorType::COMBINED_IMAGE_SAMPLER | vk::DescriptorType::SAMPLED_IMAGE => {
@@ -2891,7 +2890,7 @@ impl Resolver {
                         tls.image_infos.push(vk::DescriptorImageInfo {
                             image_layout,
                             image_view,
-                            sampler,
+                            sampler: vk::Sampler::null(),
                         });
                     } else if let Some(buffer) = bound_node.as_driver_buffer() {
                         let view_info = view_info.as_ref().unwrap();
@@ -2941,14 +2940,6 @@ impl Resolver {
                 }
 
                 if let ExecutionPipeline::Graphic(pipeline) = pipeline {
-                    for descriptor_binding in pipeline.separate_samplers.iter().copied() {
-                        tls.image_infos.push(vk::DescriptorImageInfo {
-                            image_layout: Default::default(),
-                            image_view: Default::default(),
-                            sampler: **pipeline.descriptor_bindings[&descriptor_binding].0.sampler().unwrap(),
-                        });
-                    }
-
                     // Write graphic render pass input attachments (they're automatic)
                     if exec_idx > 0 {
                         for (&DescriptorBinding(descriptor_set_idx, dst_binding), (descriptor_info, _)) in
@@ -2989,7 +2980,6 @@ impl Resolver {
                                     ty: image.info.ty,
                                 };
                                 let image_view = Image::view(image, image_view_info)?;
-                                let sampler = descriptor_info.sampler().map(|sampler| **sampler).unwrap_or_else(vk::Sampler::null);
 
                                 tls.image_writes.push(IndexWrite {
                                     idx: tls.image_infos.len(),
@@ -3010,7 +3000,7 @@ impl Resolver {
                                         true,
                                     ),
                                     image_view,
-                                    sampler,
+                                    sampler: vk::Sampler::null(),
                                 });
                             }
                         }

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -2941,18 +2941,7 @@ impl Resolver {
                 }
 
                 if let ExecutionPipeline::Graphic(pipeline) = pipeline {
-                    for descriptor_binding @ DescriptorBinding(descriptor_set_idx, dst_binding) in pipeline.separate_samplers.iter().copied() {
-                        tls.image_writes.push(IndexWrite {
-                            idx: tls.image_infos.len(),
-                            write: vk::WriteDescriptorSet {
-                                    dst_set: *descriptor_sets[descriptor_set_idx as usize],
-                                    dst_binding,
-                                    descriptor_type: vk::DescriptorType::SAMPLER,
-                                    descriptor_count: 1,
-                                    ..Default::default()
-                                },
-                            }
-                        );
+                    for descriptor_binding in pipeline.separate_samplers.iter().copied() {
                         tls.image_infos.push(vk::DescriptorImageInfo {
                             image_layout: Default::default(),
                             image_view: Default::default(),


### PR DESCRIPTION
The image_sampler example with `--separate` (with either hlsl or glsl) was resulting in this vulkan validation error:

```
VUID-VkWriteDescriptorSet-descriptorType-02752(ERROR / SPEC): msgNum: -1422077154 - Validation Error: [ VUID-VkWriteDescriptorSet-descriptorType-02752 ] Object 0: handle = 0x625f640000000058, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; 
| MessageID = 0xab3cd31e | vkUpdateDescriptorSets(): pDescriptorWrites[1] Attempted write update to an immutable sampler descriptor. The Vulkan spec states: If descriptorType is VK_DESCRIPTOR_TYPE_SAMPLER, then dstSet must not have been allocated with a layout that included immutable samplers for dstBinding (https://vulkan.lunarg.com/doc/view/1.3.280.0/windows/1.3-extensions/vkspec.html#VUID-VkWriteDescriptorSet-descriptorType-02752)
```

It was also crashing if run in render doc.

I think the sampler does not need to be updated in the descriptor binding in this case since it is already included immutably.

Sorry it took me so long to get around to testing this. Thanks so much for implementing it! Besides this issue it seems to be working great!