### PR TITLE
Make ResolverPool send to allow for resolve/submit on a different thread.

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -231,6 +231,7 @@ pub trait ResolverPool:
     Pool<DescriptorPoolInfo, DescriptorPool>
     + Pool<RenderPassInfo, RenderPass>
     + Pool<CommandBufferInfo, CommandBuffer>
+    + Send
 {
 }
 
@@ -238,5 +239,6 @@ impl<T> ResolverPool for T where
     T: Pool<DescriptorPoolInfo, DescriptorPool>
         + Pool<RenderPassInfo, RenderPass>
         + Pool<CommandBufferInfo, CommandBuffer>
+        + Send
 {
 }


### PR DESCRIPTION
 Would it be possible to allow for resolve/submit on a different thread?

I'm currently using this to get some initial pipelined rendering working where the graph is built on one thread and then resolved/submitted on another.

Here's a screenshot from tracy with before and after.

![image](https://github.com/user-attachments/assets/8eef2133-b7d1-4e12-8ce9-1c06023b9946)

