### PR TITLE
Swapchain performance/correctness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ spirq = "1.2"
 vk-sync = { path = "contrib/vk-sync" } #git = "https://github.com/attackgoat/vk-sync-rs.git", rev = "19fc3f811cc1d38b2231cdb8840fddf271879ac1", package = "vk-sync-fork" } #version = "0.4.0", package = "vk-sync-fork" }  # // SEE: https://github.com/gwihlidal/vk-sync-rs/pull/4 -> https://github.com/expenses/vk-sync-rs
 
 [target.'cfg(target_os = "macos")'.dependencies]
-ash-molten = "0.19"
+ash-molten = "0.20"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/contrib/screen-13-window/src/lib.rs
+++ b/contrib/screen-13-window/src/lib.rs
@@ -347,6 +347,12 @@ impl Window {
 
         self.event_loop.run_app(&mut app)?;
 
+        if let Some(ActiveWindow { display, swapchain, window, .. }) = app.active_window.take() {
+            drop(display);
+            drop(swapchain);
+            drop(window);
+        }
+
         info!("Window closed");
 
         if let Some(err) = app.error {

--- a/contrib/screen-13-window/src/lib.rs
+++ b/contrib/screen-13-window/src/lib.rs
@@ -3,7 +3,7 @@ mod frame;
 pub use self::frame::FrameContext;
 
 use {
-    log::{info, warn},
+    log::{info,trace, warn},
     screen_13::{
         driver::{
             ash::vk,
@@ -14,7 +14,7 @@ use {
         },
         graph::RenderGraph,
         pool::hash::HashPool,
-        Display,
+        Display, DisplayError, DisplayInfoBuilder,
     },
     std::{error, fmt, sync::Arc},
     winit::{
@@ -67,12 +67,10 @@ impl Window {
         }
 
         impl<F> Application<F> {
-            fn create_display_swapchain(
+            fn create_display(
                 &mut self,
                 window: &winit::window::Window,
-            ) -> Result<(Display, Swapchain), DriverError> {
-                let display_pool = Box::new(HashPool::new(&self.device));
-                let display = Display::new(&self.device, display_pool, self.data.cmd_buf_count, 0)?;
+            ) -> Result<Display, DriverError> {
                 let surface = Surface::create(&self.device, &window)?;
                 let surface_formats = Surface::formats(&surface)?;
                 let surface_format = self
@@ -96,10 +94,15 @@ impl Window {
                 }
 
                 let swapchain = Swapchain::new(&self.device, surface, swapchain_info)?;
+                let display = Display::new(
+                    &self.device,
+                    swapchain,
+                    DisplayInfoBuilder::default().command_buffer_count(self.data.cmd_buf_count),
+                )?;
 
-                info!("Created swapchain");
+                trace!("created display");
 
-                Ok((display, swapchain))
+                Ok(display)
             }
 
             fn window_mode_attributes(
@@ -210,7 +213,7 @@ impl Window {
                     }
                     Ok(res) => res,
                 };
-                let (display, swapchain) = match self.create_display_swapchain(&window) {
+                let display = match self.create_display(&window) {
                     Err(err) => {
                         warn!("Unable to create swapchain: {err}");
 
@@ -221,15 +224,20 @@ impl Window {
                     }
                     Ok(res) => res,
                 };
+                let display_pool = HashPool::new(&self.device);
 
                 let mut active_window = ActiveWindow {
                     display,
+                    display_pool,
                     events: vec![],
-                    swapchain,
                     window,
                 };
 
-                if !active_window.draw(&self.device, &mut self.draw_fn) {
+                let draw = active_window.draw(&self.device, &mut self.draw_fn);
+
+                profiling::finish_frame!();
+
+                if !draw.unwrap() {
                     event_loop.exit();
                     return;
                 }
@@ -252,20 +260,24 @@ impl Window {
                 if let Some(active_window) = self.active_window.as_mut() {
                     match &event {
                         WindowEvent::CloseRequested => {
-                            info!("Close requested");
+                            info!("close requested");
 
                             event_loop.exit();
                         }
                         WindowEvent::RedrawRequested => {
-                            if !active_window.draw(&self.device, &mut self.draw_fn) {
+                            let draw = active_window.draw(&self.device, &mut self.draw_fn);
+
+                            profiling::finish_frame!();
+
+                            if !draw.unwrap() {
                                 event_loop.exit();
                             }
                         }
                         WindowEvent::Resized(size) => {
-                            let mut swapchain_info = active_window.swapchain.info();
+                            let mut swapchain_info = active_window.display.swapchain_info();
                             swapchain_info.width = size.width;
                             swapchain_info.height = size.height;
-                            active_window.swapchain.set_info(swapchain_info);
+                            active_window.display.set_swapchain_info(swapchain_info);
                         }
                         _ => (),
                     }
@@ -279,23 +291,25 @@ impl Window {
 
         struct ActiveWindow {
             display: Display,
+            display_pool: HashPool,
             events: Vec<Event<()>>,
-            swapchain: Swapchain,
             window: winit::window::Window,
         }
 
         impl ActiveWindow {
-            fn draw(&mut self, device: &Arc<Device>, mut f: impl FnMut(FrameContext)) -> bool {
-                if let Ok(swapchain_image) = self.swapchain.acquire_next_image() {
-                    self.window.pre_present_notify();
-
+            fn draw(
+                &mut self,
+                device: &Arc<Device>,
+                mut f: impl FnMut(FrameContext),
+            ) -> Result<bool, DisplayError> {
+                if let Some(swapchain_image) = self.display.acquire_next_image()? {
                     let mut render_graph = RenderGraph::new();
                     let swapchain_image = render_graph.bind_node(swapchain_image);
-                    let swapchain_info = self.swapchain.info();
+                    let swapchain_info = self.display.swapchain_info();
 
                     let mut will_exit = false;
 
-                    info!("Drawing");
+                    trace!("drawing");
 
                     f(FrameContext {
                         device,
@@ -311,28 +325,24 @@ impl Window {
                     self.events.clear();
 
                     if will_exit {
-                        info!("Exit requested");
+                        info!("exit requested");
 
-                        return false;
+                        return Ok(false);
                     }
 
-                    match self.display.resolve_image(render_graph, swapchain_image) {
-                        Err(err) => {
-                            warn!("Unable to resolve swapchain image: {err}");
-
-                            return false;
-                        }
-                        Ok(swapchain_image) => self.swapchain.present_image(swapchain_image, 0, 0),
-                    }
+                    self.window.pre_present_notify();
+                    self.display
+                        .present_image(&mut self.display_pool, render_graph, swapchain_image, 0)
+                        .inspect_err(|err| {
+                            warn!("unable to present swapchain image: {err}");
+                        })?;
                 } else {
-                    warn!("Failed to acquire swapchain image");
+                    warn!("unable to acquire swapchain image");
                 }
-
-                profiling::finish_frame!();
 
                 self.window.request_redraw();
 
-                true
+                Ok(true)
             }
         }
 
@@ -347,9 +357,11 @@ impl Window {
 
         self.event_loop.run_app(&mut app)?;
 
-        if let Some(ActiveWindow { display, swapchain, window, .. }) = app.active_window.take() {
+        if let Some(ActiveWindow {
+            display, window, ..
+        }) = app.active_window.take()
+        {
             drop(display);
-            drop(swapchain);
             drop(window);
         }
 

--- a/examples/app.rs
+++ b/examples/app.rs
@@ -1,3 +1,5 @@
+mod profile_with_puffin;
+
 use {
     clap::Parser,
     log::error,
@@ -22,6 +24,9 @@ use {
 };
 
 fn main() -> Result<(), EventLoopError> {
+    pretty_env_logger::init();
+    profile_with_puffin::init();
+
     EventLoop::new()?.run_app(&mut Application::default())
 }
 

--- a/examples/cpu_readback.rs
+++ b/examples/cpu_readback.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), DriverError> {
 
     // Resolve and wait (or you can check has_executed without blocking) - alternatively you might
     // use device.queue_wait_idle(0) or device.device_wait_idle() - but those block on larger scopes
-    let cmd_buf = render_graph
+    let mut cmd_buf = render_graph
         .resolve()
         .submit(&mut HashPool::new(&device), 0, 0)?;
 

--- a/examples/msaa.rs
+++ b/examples/msaa.rs
@@ -178,7 +178,7 @@ fn best_depth_format(device: &Device) -> vk::Format {
             vk::ImageCreateFlags::empty(),
         );
 
-        if format_props.is_ok() {
+        if matches!(format_props, Ok(Some(_))) {
             return format;
         }
     }

--- a/examples/multipass.rs
+++ b/examples/multipass.rs
@@ -155,7 +155,7 @@ fn best_depth_stencil_format(device: &Device) -> vk::Format {
             vk::ImageCreateFlags::empty(),
         );
 
-        if format_props.is_ok() {
+        if matches!(format_props, Ok(Some(_))) {
             return format;
         }
     }

--- a/examples/ray_omni.rs
+++ b/examples/ray_omni.rs
@@ -138,7 +138,7 @@ fn best_2d_optimal_format(
             flags,
         );
 
-        if format_props.is_ok() {
+        if matches!(format_props, Ok(Some(_))) {
             return *format;
         }
     }

--- a/examples/subgroup_ops.rs
+++ b/examples/subgroup_ops.rs
@@ -115,7 +115,7 @@ fn exclusive_sum(
         });
 
     let output_buf = render_graph.unbind_node(output_buf);
-    let cmd_buf = render_graph
+    let mut cmd_buf = render_graph
         .resolve()
         .submit(&mut HashPool::new(device), 0, 0)?;
 

--- a/examples/vsm_omni.rs
+++ b/examples/vsm_omni.rs
@@ -436,7 +436,7 @@ fn best_2d_optimal_format(
             flags,
         );
 
-        if format_props.is_ok() {
+        if matches!(format_props, Ok(Some(_))) {
             return *format;
         }
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,20 +1,26 @@
 use {
     super::{
         driver::{
-            device::Device, image_access_layout, swapchain::SwapchainImage, CommandBuffer,
-            CommandBufferInfo, DescriptorPool, DescriptorPoolInfo, DriverError, RenderPass,
-            RenderPassInfo,
+            device::Device,
+            image::Image,
+            image_access_layout,
+            swapchain::{Swapchain, SwapchainImage, SwapchainInfo},
+            CommandBuffer, CommandBufferInfo, DescriptorPool, DescriptorPoolInfo, DriverError,
+            RenderPass, RenderPassInfo,
         },
         graph::{node::SwapchainImageNode, RenderGraph},
         pool::Pool,
     },
+    crate::prelude::SwapchainError,
     ash::vk,
-    log::trace,
+    derive_builder::{Builder, UninitializedFieldError},
+    log::{trace, warn},
     std::{
-        cell::RefCell,
         error::Error,
         fmt::{Debug, Formatter},
+        slice,
         sync::Arc,
+        thread::panicking,
         time::Instant,
     },
     vk_sync::{cmd::pipeline_barrier, AccessType, ImageBarrier},
@@ -22,56 +28,101 @@ use {
 
 /// A physical display interface.
 pub struct Display {
-    cmd_buf_idx: usize,
-    cmd_bufs: Box<[CommandBuffer]>,
-    pool: Box<dyn ResolverPool>,
+    exec_idx: usize,
+    execs: Box<[Execution]>,
+    queue_family_idx: u32,
+    swapchain: Swapchain,
 }
 
 impl Display {
     /// Constructs a new `Display` object.
     pub fn new(
         device: &Arc<Device>,
-        pool: Box<dyn ResolverPool>,
-        cmd_buf_count: usize,
-        queue_family_index: u32,
+        swapchain: Swapchain,
+        info: impl Into<DisplayInfo>,
     ) -> Result<Self, DriverError> {
-        let mut cmd_bufs = Vec::with_capacity(cmd_buf_count);
-        for _ in 0..cmd_buf_count {
-            cmd_bufs.push(CommandBuffer::create(
-                device,
-                CommandBufferInfo::new(queue_family_index),
-            )?);
+        let info: DisplayInfo = info.into();
+
+        assert_ne!(info.command_buffer_count, 0);
+
+        let mut execs = Vec::with_capacity(info.command_buffer_count as _);
+        for _ in 0..info.command_buffer_count {
+            let cmd_buf =
+                CommandBuffer::create(device, CommandBufferInfo::new(info.queue_family_index))?;
+            let swapchain_acquired = Device::create_semaphore(device)?;
+            let swapchain_rendered = Device::create_semaphore(device)?;
+
+            execs.push(Execution {
+                cmd_buf,
+                queue: None,
+                swapchain_acquired,
+                swapchain_rendered,
+            });
         }
-        let cmd_bufs = cmd_bufs.into_boxed_slice();
+        let execs = execs.into_boxed_slice();
 
         Ok(Self {
-            cmd_buf_idx: 0,
-            cmd_bufs,
-            pool,
+            exec_idx: info.command_buffer_count,
+            execs,
+            queue_family_idx: info.queue_family_index,
+            swapchain,
         })
     }
 
-    #[profiling::function]
-    unsafe fn begin(cmd_buf: &CommandBuffer) -> Result<(), ()> {
-        cmd_buf
-            .device
-            .begin_command_buffer(
-                **cmd_buf,
-                &vk::CommandBufferBeginInfo::default()
-                    .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
-            )
-            .map_err(|_| ())
+    /// Gets the next available swapchain image which should be rendered to and then presented using
+    /// [`present_image`][Self::present_image].
+    pub fn acquire_next_image(&mut self) -> Result<Option<SwapchainImage>, DisplayError> {
+        self.exec_idx += 1;
+        self.exec_idx %= self.execs.len();
+        let exec = &mut self.execs[self.exec_idx];
+
+        if exec.queue.is_some() {
+            CommandBuffer::wait_until_executed(&mut exec.cmd_buf).inspect_err(|err| {
+                warn!("unable to wait for display fence: {err}");
+            })?;
+
+            exec.queue = None;
+        }
+
+        CommandBuffer::drop_fenced(&mut exec.cmd_buf);
+
+        unsafe {
+            exec.cmd_buf
+                .device
+                .reset_fences(slice::from_ref(&exec.cmd_buf.fence))
+                .map_err(|err| {
+                    warn!("unable to reset display fence: {err}");
+
+                    DriverError::InvalidData
+                })?;
+        }
+
+        let acquire_next_image = self.swapchain.acquire_next_image(exec.swapchain_acquired);
+
+        if let Err(err) = acquire_next_image {
+            warn!("unable to acquire next swapchain image: {err:?}");
+        }
+
+        let mut swapchain_image = match acquire_next_image {
+            Err(SwapchainError::DeviceLost) => Err(DisplayError::DeviceLost),
+            Err(SwapchainError::Suboptimal) => return Ok(None),
+            Err(SwapchainError::SurfaceLost) => Err(DisplayError::Driver(DriverError::InvalidData)),
+            Ok(swapchain_image) => Ok(swapchain_image),
+        }?;
+        swapchain_image.exec_idx = self.exec_idx;
+
+        Ok(Some(swapchain_image))
     }
 
     /// Displays the given swapchain image using passes specified in `render_graph`, if possible.
     #[profiling::function]
-    pub fn resolve_image(
+    pub fn present_image(
         &mut self,
+        pool: &mut impl ResolverPool,
         render_graph: RenderGraph,
         swapchain_image: SwapchainImageNode,
-    ) -> Result<SwapchainImage, DisplayError> {
-        use std::slice::from_ref;
-
+        queue_index: u32,
+    ) -> Result<(), DisplayError> {
         trace!("present_image");
 
         let mut resolver = render_graph.resolve();
@@ -83,33 +134,31 @@ impl Display {
             "uninitialized swapchain image: write something each frame!",
         );
 
-        self.cmd_buf_idx += 1;
-        self.cmd_buf_idx %= self.cmd_bufs.len();
+        let exec_idx = resolver.swapchain_image(swapchain_image).exec_idx;
+        let exec = &mut self.execs[exec_idx];
 
-        let cmd_buf = unsafe { self.cmd_bufs.get_unchecked_mut(self.cmd_buf_idx) };
+        debug_assert!(exec.queue.is_none());
 
         let started = Instant::now();
 
         unsafe {
-            Self::wait_for_fence(cmd_buf)?;
-        }
-
-        unsafe {
-            Self::begin(cmd_buf)?;
+            exec.cmd_buf
+                .device
+                .begin_command_buffer(
+                    *exec.cmd_buf,
+                    &vk::CommandBufferBeginInfo::default()
+                        .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
+                )
+                .map_err(|_| ())?;
         }
 
         // resolver.record_node_dependencies(&mut *self.pool, cmd_buf, swapchain_image)?;
-        resolver.record_node(&mut *self.pool, cmd_buf, swapchain_image)?;
+        resolver.record_node(pool, &mut exec.cmd_buf, swapchain_image)?;
 
-        let mut swapchain_image = resolver.unbind_node(swapchain_image);
-        let image = **swapchain_image;
-
-        thread_local! {
-            static TLS: RefCell<Vec<(AccessType, vk::ImageSubresourceRange)>> = Default::default();
-        }
-
-        TLS.with_borrow_mut(|tls| {
-            for (access, range) in swapchain_image.access(
+        {
+            let swapchain_image = resolver.swapchain_image(swapchain_image);
+            for (access, range) in Image::access(
+                swapchain_image,
                 AccessType::Present,
                 vk::ImageSubresourceRange {
                     aspect_mask: vk::ImageAspectFlags::COLOR,
@@ -119,109 +168,149 @@ impl Display {
                     level_count: 1,
                 },
             ) {
-                tls.push((access, range));
-
                 trace!(
-                    "swapchain image {:?} {:?}{:?}->{:?}{:?}",
-                    image,
+                    "image {:?} {:?}->{:?}",
+                    **swapchain_image,
                     access,
-                    image_access_layout(access),
                     AccessType::Present,
-                    image_access_layout(AccessType::Present),
                 );
 
                 // Force a presentation layout transition
                 pipeline_barrier(
-                    &cmd_buf.device,
-                    **cmd_buf,
+                    &exec.cmd_buf.device,
+                    *exec.cmd_buf,
                     None,
                     &[],
-                    from_ref(&ImageBarrier {
-                        previous_accesses: from_ref(&access),
+                    slice::from_ref(&ImageBarrier {
+                        previous_accesses: slice::from_ref(&access),
                         previous_layout: image_access_layout(access),
-                        next_accesses: from_ref(&AccessType::Present),
+                        next_accesses: slice::from_ref(&AccessType::Present),
                         next_layout: image_access_layout(AccessType::Present),
                         discard_contents: false,
                         src_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
                         dst_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
-                        image,
+                        image: ***swapchain_image,
                         range,
                     }),
                 );
             }
-
-            // Now force the image to actually wait on the previous operations
-            for (access, range) in tls.drain(..) {
-                for _ in swapchain_image.access(access, range) {}
-            }
-        });
+        }
 
         // We may have unresolved nodes; things like copies that happen after present or operations
         // before present which use nodes that are unused in the remainder of the graph.
         // These operations are still important, but they don't need to wait for any of the above
         // things so we do them last
-        resolver.record_unscheduled_passes(self.pool.as_mut(), cmd_buf)?;
+        resolver.record_unscheduled_passes(pool, &mut exec.cmd_buf)?;
+
+        let queue =
+            exec.cmd_buf.device.queues[self.queue_family_idx as usize][queue_index as usize];
 
         unsafe {
-            Self::submit(
-                cmd_buf,
-                vk::SubmitInfo::default()
-                    .command_buffers(from_ref(cmd_buf))
-                    .signal_semaphores(from_ref(&swapchain_image.rendered))
-                    .wait_semaphores(from_ref(&swapchain_image.acquired))
-                    .wait_dst_stage_mask(from_ref(&wait_dst_stage_mask)),
-            )?;
+            exec.cmd_buf
+                .device
+                .end_command_buffer(*exec.cmd_buf)
+                .map_err(|err| {
+                    warn!("unable to end display command buffer: {err}");
+
+                    DriverError::InvalidData
+                })?;
+            exec.cmd_buf
+                .device
+                .queue_submit(
+                    queue,
+                    slice::from_ref(
+                        &vk::SubmitInfo::default()
+                            .command_buffers(slice::from_ref(&exec.cmd_buf))
+                            .wait_semaphores(slice::from_ref(&exec.swapchain_acquired))
+                            .wait_dst_stage_mask(slice::from_ref(&wait_dst_stage_mask))
+                            .signal_semaphores(slice::from_ref(&exec.swapchain_rendered)),
+                    ),
+                    exec.cmd_buf.fence,
+                )
+                .map_err(|err| {
+                    warn!("unable to submit display command buffer: {err}");
+
+                    DriverError::InvalidData
+                })?
         }
+
+        exec.cmd_buf.waiting = true;
+        exec.queue = Some(queue);
 
         let elapsed = Instant::now() - started;
         trace!("🔜🔜🔜 vkQueueSubmit took {} μs", elapsed.as_micros(),);
 
+        let swapchain_image =
+            SwapchainImage::clone_swapchain(resolver.swapchain_image(swapchain_image));
+
+        self.swapchain.present_image(
+            swapchain_image,
+            slice::from_ref(&exec.swapchain_rendered),
+            self.queue_family_idx,
+            queue_index,
+        );
+
         // Store the resolved graph because it contains bindings, leases, and other shared resources
         // that need to be kept alive until the fence is waited upon.
-        CommandBuffer::push_fenced_drop(cmd_buf, resolver);
+        CommandBuffer::push_fenced_drop(&mut exec.cmd_buf, resolver);
 
-        // HACK: Until swapchain gets a better design to track completed command buffers
-        CommandBuffer::push_fenced_semaphore(cmd_buf, swapchain_image.acquired);
-        swapchain_image.acquired = vk::Semaphore::null();
-
-        Ok(swapchain_image)
+        Ok(())
     }
 
-    #[profiling::function]
-    unsafe fn submit(cmd_buf: &CommandBuffer, submit_info: vk::SubmitInfo<'_>) -> Result<(), ()> {
-        use std::slice::from_ref;
-
-        cmd_buf
-            .device
-            .end_command_buffer(**cmd_buf)
-            .map_err(|_| ())?;
-        cmd_buf
-            .device
-            .queue_submit(
-                cmd_buf.device.queues[cmd_buf.info.queue_family_index as usize][0],
-                from_ref(&submit_info),
-                cmd_buf.fence,
-            )
-            .map_err(|_| ())
+    /// Sets information about the swapchain.
+    ///
+    /// Previously acquired swapchain images should be discarded after calling this function.
+    pub fn set_swapchain_info(&mut self, info: impl Into<SwapchainInfo>) {
+        self.swapchain.set_info(info);
     }
 
-    #[profiling::function]
-    unsafe fn wait_for_fence(cmd_buf: &mut CommandBuffer) -> Result<(), ()> {
-        use std::slice::from_ref;
-
-        Device::wait_for_fence(&cmd_buf.device, &cmd_buf.fence).map_err(|_| ())?;
-        CommandBuffer::drop_fenced(cmd_buf);
-
-        cmd_buf
-            .device
-            .reset_fences(from_ref(&cmd_buf.fence))
-            .map_err(|_| ())
+    /// Gets information about the swapchain.
+    pub fn swapchain_info(&self) -> SwapchainInfo {
+        self.swapchain.info()
     }
 }
 
 impl Debug for Display {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str("Display")
+    }
+}
+
+impl Drop for Display {
+    fn drop(&mut self) {
+        if panicking() {
+            return;
+        }
+
+        let idle = unsafe { self.execs[0].cmd_buf.device.device_wait_idle() };
+        if idle.is_err() {
+            warn!("unable to wait for device");
+
+            return;
+        }
+
+        for batch in &mut self.execs {
+            if let Some(queue) = batch.queue {
+                // Wait for presentation to stop
+                let present = unsafe { batch.cmd_buf.device.queue_wait_idle(queue) };
+                if present.is_err() {
+                    warn!("unable to wait for queue");
+
+                    continue;
+                }
+            }
+
+            unsafe {
+                batch
+                    .cmd_buf
+                    .device
+                    .destroy_semaphore(batch.swapchain_acquired, None);
+                batch
+                    .cmd_buf
+                    .device
+                    .destroy_semaphore(batch.swapchain_rendered, None);
+            }
+        }
     }
 }
 
@@ -255,6 +344,92 @@ impl std::fmt::Display for DisplayError {
     }
 }
 
+/// Information used to create a [`Display`] instance.
+#[derive(Builder, Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[builder(
+    build_fn(private, name = "fallible_build", error = "DisplayInfoBuilderError"),
+    derive(Clone, Copy, Debug),
+    pattern = "owned"
+)]
+#[non_exhaustive]
+pub struct DisplayInfo {
+    /// The number of command buffers to use for image submissions.
+    ///
+    /// Generally one more than the swapchain image count is best.
+    #[builder(default = "4")]
+    command_buffer_count: usize,
+
+    /// The device queue family which will be used to submit and present images.
+    #[builder(default = "0")]
+    queue_family_index: u32,
+}
+
+impl DisplayInfo {
+    /// Converts a `DisplayInfo` into a `DisplayInfoBuilder`.
+    #[inline(always)]
+    pub fn to_builder(self) -> DisplayInfoBuilder {
+        DisplayInfoBuilder {
+            command_buffer_count: Some(self.command_buffer_count),
+            queue_family_index: Some(self.queue_family_index),
+        }
+    }
+}
+
+impl Default for DisplayInfo {
+    fn default() -> Self {
+        Self {
+            command_buffer_count: 4,
+            queue_family_index: 0,
+        }
+    }
+}
+
+impl From<DisplayInfoBuilder> for DisplayInfo {
+    fn from(info: DisplayInfoBuilder) -> Self {
+        info.build()
+    }
+}
+
+impl DisplayInfoBuilder {
+    /// Builds a new `DisplayInfo`.
+    ///
+    /// # Panics
+    ///
+    /// If any of the following values have not been set this function will panic:
+    ///
+    /// * `command_buffer_count`
+    #[inline(always)]
+    pub fn build(self) -> DisplayInfo {
+        let info = match self.fallible_build() {
+            Err(DisplayInfoBuilderError(err)) => panic!("{err}"),
+            Ok(info) => info,
+        };
+
+        assert_ne!(
+            info.command_buffer_count, 0,
+            "Field value invalid: command_buffer_count"
+        );
+
+        info
+    }
+}
+
+#[derive(Debug)]
+struct DisplayInfoBuilderError(UninitializedFieldError);
+
+impl From<UninitializedFieldError> for DisplayInfoBuilderError {
+    fn from(err: UninitializedFieldError) -> Self {
+        Self(err)
+    }
+}
+
+struct Execution {
+    cmd_buf: CommandBuffer,
+    queue: Option<vk::Queue>,
+    swapchain_acquired: vk::Semaphore,
+    swapchain_rendered: vk::Semaphore,
+}
+
 /// Combination trait which groups together all [`Pool`] traits required for a [`Resolver`]
 /// instance.
 ///
@@ -274,4 +449,51 @@ impl<T> ResolverPool for T where
         + Pool<CommandBufferInfo, CommandBuffer>
         + Send
 {
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type Info = DisplayInfo;
+    type Builder = DisplayInfoBuilder;
+
+    #[test]
+    pub fn display_info() {
+        let info = Info {
+            command_buffer_count: 42,
+            queue_family_index: 16,
+        };
+        let builder = info.to_builder().build();
+
+        assert_eq!(info, builder);
+    }
+
+    #[test]
+    pub fn display_info_builder() {
+        let info = Info {
+            command_buffer_count: 42,
+            queue_family_index: 16,
+        };
+        let builder = Builder::default()
+            .command_buffer_count(42)
+            .queue_family_index(16)
+            .build();
+
+        assert_eq!(info, builder);
+    }
+
+    #[test]
+    pub fn display_info_default() {
+        let info = Info::default();
+        let builder = Builder::default().build();
+
+        assert_eq!(info, builder);
+    }
+
+    #[test]
+    #[should_panic(expected = "Field value invalid: command_buffer_count")]
+    pub fn display_info_builder_uninit_command_buffer_count() {
+        Builder::default().command_buffer_count(0).build();
+    }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -180,6 +180,10 @@ impl Display {
         // that need to be kept alive until the fence is waited upon.
         CommandBuffer::push_fenced_drop(cmd_buf, resolver);
 
+        // HACK: Until swapchain gets a better design to track completed command buffers
+        CommandBuffer::push_fenced_semaphore(cmd_buf, swapchain_image.acquired);
+        swapchain_image.acquired = vk::Semaphore::null();
+
         Ok(swapchain_image)
     }
 

--- a/src/driver/cmd_buf.rs
+++ b/src/driver/cmd_buf.rs
@@ -86,10 +86,6 @@ impl CommandBuffer {
     /// See [`Self::wait_until_executed`] to block while checking.
     #[profiling::function]
     pub fn has_executed(&self) -> Result<bool, DriverError> {
-        if !self.waiting {
-            return Ok(false);
-        }
-
         let res = unsafe { self.device.get_fence_status(self.fence) };
 
         match res {

--- a/src/driver/device.rs
+++ b/src/driver/device.rs
@@ -287,6 +287,15 @@ impl Device {
             .expect("VK_KHR_acceleration_structure")
     }
 
+    /// Helper for times when you already know that the device supports the swapchain extension.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the device was not created for swapchain access.
+    pub(crate) fn expect_swapchain_ext(this: &Self) -> &khr::swapchain::Device {
+        this.swapchain_ext.as_ref().expect("VK_KHR_swapchain")
+    }
+
     /// Loads and existing `ash` Vulkan device that may have been created by other means.
     #[profiling::function]
     pub fn load(

--- a/src/driver/device.rs
+++ b/src/driver/device.rs
@@ -287,11 +287,20 @@ impl Device {
             .expect("VK_KHR_acceleration_structure")
     }
 
+    /// Helper for times when you already know that the instance supports the surface extension.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the device was not created for display window access.
+    pub(crate) fn expect_surface_ext(this: &Self) -> &khr::surface::Instance {
+        this.surface_ext.as_ref().expect("VK_KHR_surface")
+    }
+
     /// Helper for times when you already know that the device supports the swapchain extension.
     ///
     /// # Panics
     ///
-    /// Panics if the device was not created for swapchain access.
+    /// Panics if the device was not created for display window access.
     pub(crate) fn expect_swapchain_ext(this: &Self) -> &khr::swapchain::Device {
         this.swapchain_ext.as_ref().expect("VK_KHR_swapchain")
     }

--- a/src/driver/image.rs
+++ b/src/driver/image.rs
@@ -287,7 +287,7 @@ impl Image {
     }
 
     #[profiling::function]
-    pub(super) fn clone_raw(this: &Self) -> Self {
+    pub(super) fn clone_swapchain(this: &Self) -> Self {
         // Moves the image view cache from the current instance to the clone!
         #[cfg_attr(not(feature = "parking_lot"), allow(unused_mut))]
         let mut image_view_cache = this.image_view_cache.lock();
@@ -297,15 +297,9 @@ impl Image {
 
         let image_view_cache = take(&mut *image_view_cache);
 
-        // Moves the image accesses from the current instance to the clone!
-        #[cfg_attr(not(feature = "parking_lot"), allow(unused_mut))]
-        let mut accesses = this.accesses.lock();
-
-        #[cfg(not(feature = "parking_lot"))]
-        let mut accesses = accesses.unwrap();
-
+        // Does NOT copy over the image accesses!
         let Self { image, info, .. } = *this;
-        let accesses = Mutex::new(replace(&mut *accesses, ImageAccess::new(info)));
+        let accesses = Mutex::new(ImageAccess::new(info));
 
         Self {
             accesses,

--- a/src/driver/image.rs
+++ b/src/driver/image.rs
@@ -299,7 +299,14 @@ impl Image {
 
         // Does NOT copy over the image accesses!
         let Self { image, info, .. } = *this;
-        let accesses = Mutex::new(ImageAccess::new(info));
+        let mut accesses = ImageAccess::new(info);
+
+        // Force previous access to general to wait for presentation
+        for access in &mut accesses.accesses {
+            *access = AccessType::General;
+        }
+
+        let accesses = Mutex::new(accesses);
 
         Self {
             accesses,

--- a/src/driver/instance.rs
+++ b/src/driver/instance.rs
@@ -155,6 +155,10 @@ impl Instance {
 
         trace!("created a Vulkan instance");
 
+        #[cfg(target_os = "macos")]
+        let (debug_loader, debug_callback, debug_utils) = (None, None, None);
+
+        #[cfg(not(target_os = "macos"))]
         let (debug_loader, debug_callback, debug_utils) = if debug {
             let debug_info = vk::DebugReportCallbackCreateInfoEXT {
                 flags: vk::DebugReportFlagsEXT::ERROR
@@ -216,9 +220,13 @@ impl Instance {
         &this.entry
     }
 
-    unsafe fn extension_names(debug: bool) -> Vec<*const i8> {
+    unsafe fn extension_names(
+        #[cfg_attr(target_os = "macos", allow(unused_variables))] debug: bool,
+    ) -> Vec<*const c_char> {
+        #[cfg_attr(target_os = "macos", allow(unused_mut))]
         let mut res = vec![];
 
+        #[cfg(not(target_os = "macos"))]
         if debug {
             #[allow(deprecated)]
             res.push(ext::debug_report::NAME.as_ptr());
@@ -233,13 +241,15 @@ impl Instance {
         this.debug_utils.is_some()
     }
 
-    fn layer_names(debug: bool) -> Vec<CString> {
-        let mut res = Vec::new();
+    fn layer_names(
+        #[cfg_attr(target_os = "macos", allow(unused_variables))] debug: bool,
+    ) -> Vec<CString> {
+        #[cfg_attr(target_os = "macos", allow(unused_mut))]
+        let mut res = vec![];
 
+        #[cfg(not(target_os = "macos"))]
         if debug {
-            if let Ok(name) = CString::new("VK_LAYER_KHRONOS_validation") {
-                res.push(name);
-            }
+            res.push(CString::new("VK_LAYER_KHRONOS_validation").unwrap());
         }
 
         res

--- a/src/driver/instance.rs
+++ b/src/driver/instance.rs
@@ -1,21 +1,31 @@
 use {
     super::{physical_device::PhysicalDevice, DriverError},
     ash::{ext, vk, Entry},
-    log::{debug, error, info, logger, trace, warn, Level, Metadata},
+    log::{debug, error, trace, warn},
     std::{
-        env::var,
-        ffi::{c_void, CStr, CString},
+        ffi::{CStr, CString},
         fmt::{Debug, Formatter},
         ops::Deref,
         os::raw::c_char,
+        thread::panicking,
+    },
+};
+
+#[cfg(not(target_os = "macos"))]
+use {
+    log::{info, logger, Level, Metadata},
+    std::{
+        env::var,
+        ffi::c_void,
         process::id,
-        thread::{current, panicking, park},
+        thread::{current, park},
     },
 };
 
 #[cfg(target_os = "macos")]
 use std::env::set_var;
 
+#[cfg(not(target_os = "macos"))]
 unsafe extern "system" fn vulkan_debug_callback(
     _flags: vk::DebugReportFlagsEXT,
     _obj_type: vk::DebugReportObjectTypeEXT,

--- a/src/driver/surface.rs
+++ b/src/driver/surface.rs
@@ -151,12 +151,10 @@ impl Drop for Surface {
             return;
         }
 
+        let surface_ext = Device::expect_surface_ext(&self.device);
+
         unsafe {
-            self.device
-                .surface_ext
-                .as_ref()
-                .unwrap()
-                .destroy_surface(self.surface, None);
+            surface_ext.destroy_surface(self.surface, None);
         }
     }
 }

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -8,7 +8,6 @@ use {
         driver::{
             accel_struct::AccelerationStructure,
             buffer::Buffer,
-            device::Device,
             format_aspect_mask,
             graphic::DepthStencilMode,
             image::{Image, ImageViewInfo},

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -1,8 +1,8 @@
 use {
     super::{
+        node::SwapchainImageNode,
         pass_ref::{Subresource, SubresourceAccess},
-        Area, Attachment, Binding, Bindings, Edge, ExecutionPipeline, Node, NodeIndex, Pass,
-        RenderGraph, Unbind,
+        Area, Attachment, Binding, Bindings, ExecutionPipeline, Node, NodeIndex, Pass, RenderGraph,
     },
     crate::{
         driver::{
@@ -13,6 +13,7 @@ use {
             graphic::DepthStencilMode,
             image::{Image, ImageViewInfo},
             image_access_layout, is_read_access, is_write_access, pipeline_stage_access_flags,
+            swapchain::SwapchainImage,
             AttachmentInfo, AttachmentRef, CommandBuffer, CommandBufferInfo, Descriptor,
             DescriptorInfo, DescriptorPool, DescriptorPoolInfo, DescriptorSet, DriverError,
             FramebufferAttachmentImageInfo, FramebufferInfo, RenderPass, RenderPassInfo,
@@ -2009,13 +2010,11 @@ impl Resolver {
                     } = *resource;
 
                     trace!(
-                        "{trace_pad}buffer {:?} {:?} {:?}{:?}->{:?}{:?}",
+                        "{trace_pad}buffer {:?} {:?} {:?}->{:?}",
                         buffer,
                         offset..offset + size,
                         prev_access,
-                        image_access_layout(*prev_access),
                         next_access,
-                        image_access_layout(*next_access),
                     );
 
                     BufferBarrier {
@@ -2058,13 +2057,11 @@ impl Resolver {
                     }
 
                     trace!(
-                        "{trace_pad}image {:?} {:?} {:?}{:?}->{:?}{:?}",
+                        "{trace_pad}image {:?} {:?} {:?}->{:?}",
                         image,
                         ImageSubresourceRangeDebug(range),
                         prev_access,
-                        image_access_layout(*prev_access),
                         next_access,
-                        image_access_layout(*next_access),
                     );
 
                     ImageBarrier {
@@ -2693,10 +2690,9 @@ impl Resolver {
             "Queue index must be within the range of the available queues created by the device."
         );
 
-        unsafe {
-            Device::wait_for_fence(&cmd_buf.device, &cmd_buf.fence)
-                .map_err(|_| DriverError::OutOfMemory)?;
+        CommandBuffer::wait_until_executed(&mut cmd_buf)?;
 
+        unsafe {
             cmd_buf
                 .device
                 .begin_command_buffer(
@@ -2728,6 +2724,8 @@ impl Resolver {
                 .map_err(|_| DriverError::OutOfMemory)?;
         }
 
+        cmd_buf.waiting = true;
+
         // This graph contains references to buffers, images, and other resources which must be kept
         // alive until this graph execution completes on the GPU. Once those references are dropped
         // they will return to the pool for other things to use. The drop will happen the next time
@@ -2738,12 +2736,12 @@ impl Resolver {
         Ok(cmd_buf)
     }
 
-    pub(crate) fn unbind_node<N>(&mut self, node: N) -> <N as Edge<Self>>::Result
-    where
-        N: Edge<Self>,
-        N: Unbind<Self, <N as Edge<Self>>::Result>,
-    {
-        node.unbind(self)
+    pub(crate) fn swapchain_image(&mut self, node: SwapchainImageNode) -> &SwapchainImage {
+        let Some(swapchain_image) = self.graph.bindings[node.idx].as_swapchain_image() else {
+            panic!("invalid swapchain image node");
+        };
+
+        swapchain_image
     }
 
     #[profiling::function]

--- a/src/graph/swapchain.rs
+++ b/src/graph/swapchain.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Bind, Binding, RenderGraph, Resolver, SwapchainImageNode, Unbind},
+    super::{Bind, Binding, RenderGraph, SwapchainImageNode},
     crate::driver::swapchain::SwapchainImage,
 };
 
@@ -29,28 +29,5 @@ impl Binding {
             // The private code in this module should prevent this branch
             unreachable!();
         }
-    }
-
-    pub(super) fn as_swapchain_image_mut(&mut self) -> Option<&mut SwapchainImage> {
-        if let Self::SwapchainImage(binding, true) = self {
-            Some(binding)
-        } else if let Self::SwapchainImage(_, false) = self {
-            // User code might try this - but it is a programmer error
-            // to access a binding after it has been unbound so dont
-            None
-        } else {
-            // The private code in this module should prevent this branch
-            unreachable!();
-        }
-    }
-}
-
-impl Unbind<Resolver, SwapchainImage> for SwapchainImageNode {
-    // We allow the resolver to unbind a swapchain node directly into a shared image
-    fn unbind(self, graph: &mut Resolver) -> SwapchainImage {
-        graph.graph.bindings[self.idx]
-            .as_swapchain_image_mut()
-            .unwrap()
-            .unbind()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,7 +329,7 @@ mod display;
 /// Things which are used in almost every single _Screen 13_ program.
 pub mod prelude {
     pub use super::{
-        display::{Display, DisplayError, ResolverPool},
+        display::{Display, DisplayError, DisplayInfo, DisplayInfoBuilder, ResolverPool},
         driver::{
             accel_struct::{
                 AccelerationStructure, AccelerationStructureGeometry,
@@ -389,4 +389,4 @@ pub mod prelude {
     };
 }
 
-pub use self::display::{Display, DisplayError, ResolverPool};
+pub use self::display::{Display, DisplayError, DisplayInfo, DisplayInfoBuilder, ResolverPool};


### PR DESCRIPTION
Modifies the `Display` struct to own a `Swapchain`, instead of operating in conjunction with it. Fixes the incorrect "image ready" fence which was waited upon before submitting new frames.

_The previous behavior was unsound and only worked on certain hardware._

The new pattern greatly simplifies swapchain handling:
- A list of command buffers available to execute frame submissions is kept in `Display`
- The list of command buffers may have 1 or more items, up to and beyond the number of swapchain images

Process:
- `vkAcquireNextImageKHR` signals an "acquire" semaphore when the image is available
- Rendering commands wait for "acquire" and signal a "rendered" semaphore
- `vkQueuePresentKHR` waits for "rendered" before presenting the image

Additionally, recreating the swapchain no longer uses `vkDeviceWaitIdle`. This improves window resizing performance.