### PR TITLE
fix: missing access for the present transition and fix crash due to missing active extension

### DIFF
--- a/src/driver/swapchain.rs
+++ b/src/driver/swapchain.rs
@@ -443,6 +443,10 @@ impl Swapchain {
             res |= usage;
         }
 
+        // On mesa the device will return this usage flag as supported even when the extension
+        // that is needed for an image to have this flag isn't enabled
+        res &= !vk::ImageUsageFlags::ATTACHMENT_FEEDBACK_LOOP_EXT;
+
         Ok(res)
     }
 }

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -2300,7 +2300,7 @@ impl Resolver {
                                 )
                             {
                                 for (prev_access, range) in
-                                    Image::access(image, AccessType::Nothing, layout_range)
+                                    Image::access(image, access, layout_range)
                                 {
                                     tls.images.push(ImageResourceBarrier {
                                         image: **image,

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -2294,20 +2294,20 @@ impl Resolver {
                                 }
                             };
 
-                            for layout_range in
-                                initial_layout.access(false, access_range).filter_map(
-                                    |(initial, access_range)| initial.then_some(access_range),
-                                )
+                            for (initial_layout, layout_range) in
+                                initial_layout.access(false, access_range)
                             {
                                 for (prev_access, range) in
                                     Image::access(image, access, layout_range)
                                 {
-                                    tls.images.push(ImageResourceBarrier {
-                                        image: **image,
-                                        next_access: initial_image_layout_access(access),
-                                        prev_access,
-                                        range,
-                                    });
+                                    if initial_layout {
+                                        tls.images.push(ImageResourceBarrier {
+                                            image: **image,
+                                            next_access: initial_image_layout_access(access),
+                                            prev_access,
+                                            range,
+                                        });
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes #96 - Not sure if this is a good solution, but it removed all validation errors and most examples seem to be working. 

Tested on linux with:
```
apiVersion         = 1.4.305
driverVersion      = 25.0.1
vendorID           = 0x1002
deviceID           = 0x744c
deviceType         = PHYSICAL_DEVICE_TYPE_DISCRETE_GPU
deviceName         = AMD Radeon RX 7900 GRE (RADV NAVI31)
driverID           = DRIVER_ID_MESA_RADV
driverName         = radv
driverInfo         = Mesa 25.0.1
conformanceVersion = 1.4.0.0
```
	

