### PR TITLE
fix: remove debug assert for desired image count and set_var fix

### DIFF
--- a/src/driver/instance.rs
+++ b/src/driver/instance.rs
@@ -133,7 +133,9 @@ impl Instance {
     ) -> Result<Self, DriverError> {
         // Required to enable non-uniform descriptor indexing (bindless)
         #[cfg(target_os = "macos")]
-        set_var("MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", "1");
+        unsafe {
+            set_var("MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS", "1");
+        }
 
         #[cfg(not(target_os = "macos"))]
         let entry = unsafe {

--- a/src/driver/swapchain.rs
+++ b/src/driver/swapchain.rs
@@ -374,8 +374,6 @@ impl Swapchain {
             })
             .collect::<Result<Box<_>, _>>()?;
 
-        debug_assert_eq!(desired_image_count, images.len() as u32);
-
         self.info.height = surface_height;
         self.info.width = surface_width;
         self.images = images;


### PR DESCRIPTION
Vulkan can always return more images than provided in ``.min_image_count(..)``.

Ref: https://gitlab.freedesktop.org/apinheiro/mesa/-/issues/9

Quotes by a comment in that issue:

From the Vulkan spec: minImageCount is the minimum number of presentable images that the application needs. The implementation will either create the swapchain with at least that many images(...)