### PR TITLE
fix: add device_wait_idle when destroying swapchain

### DIFF
--- a/src/driver/swapchain.rs
+++ b/src/driver/swapchain.rs
@@ -161,7 +161,9 @@ impl Swapchain {
 
     #[profiling::function]
     fn destroy_swapchain(device: &Device, swapchain: &mut vk::SwapchainKHR) {
-        // TODO: Any cases where we need to wait for idle here?
+        // wait for device to be finished with swapchain before destroying it.
+        // This avoid crashes when resizing windows
+        unsafe { device.device_wait_idle() }.unwrap();
 
         if *swapchain != vk::SwapchainKHR::null() {
             let swapchain_ext = Device::expect_swapchain_ext(device);

--- a/src/driver/swapchain.rs
+++ b/src/driver/swapchain.rs
@@ -165,7 +165,9 @@ impl Swapchain {
             // wait for device to be finished with swapchain before destroying it.
             // This avoid crashes when resizing windows
             #[cfg(target_os = "macos")]
-            unsafe { device.device_wait_idle() }.unwrap();
+            if let Err(err) = unsafe { device.device_wait_idle() } {
+                warn!("device_wait_idle() failed: {err}");
+            }
 
             let swapchain_ext = Device::expect_swapchain_ext(device);
 
@@ -404,7 +406,9 @@ impl Swapchain {
         if self.info != info {
             // attempt to reducing flickering when resizing windows on mac
             #[cfg(target_os = "macos")]
-            unsafe { self.device.device_wait_idle() }.unwrap();
+            if let Err(err) = unsafe { self.device.device_wait_idle() } {
+                warn!("device_wait_idle() failed: {err}");
+            }
 
             self.info = info;
 


### PR DESCRIPTION
Hi,

this PR is more like a request for comments than an a proper actual fix.

I noticed on Mac OSX, some of the examples may crash when their windows is being resized. The example `egui` seems particularly prone to that issue.

the debugger shows that the segfault always happens in the following function:
```
; Symbol: MVKSwapchain::beginPresentation(MVKImagePresentInfo const&), mangled name=_ZN12MVKSwapchain17beginPresentationERK19MVKImagePresentInfo
```

I found this issue on MoltenVK's repo: https://github.com/KhronosGroup/MoltenVK/issues/2031
which seems to imply that  `vkDeviceWaitIdle()` should be called when a resize is being detected.

Therefore, I added a call to `device.device_wait_idle()` just before destroying the old swap_chain, and that seems quite successful on my side so far.

Another thing, perhaps related: 
some of the examples are flickering quite a bit when their window is being resized:
* `font_bmp`
* `image_sampler`
 
Once I added that call to `device_wait_idle`, the amount of flickering got reduced, but unfortunately is still happening. So perhaps this is not the right fix or there is something else happening.