### PR TITLE
Block format support

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -96,6 +96,7 @@ pub(super) const fn format_aspect_mask(fmt: vk::Format) -> vk::ImageAspectFlags 
     }
 }
 
+/// Returns number of bytes used to store one texel block (a single addressable element of an uncompressed image, or a single compressed block of a compressed image)
 /// See [Representation and Texel Block Size](https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#texel-block-size)
 pub const fn format_texel_block_size(fmt: vk::Format) -> u32 {
     match fmt {
@@ -238,6 +239,375 @@ pub const fn format_texel_block_size(fmt: vk::Format) -> u32 {
         vk::Format::D16_UNORM_S8_UINT => 3,
         vk::Format::D24_UNORM_S8_UINT => 4,
         vk::Format::D32_SFLOAT_S8_UINT => 5,
+        vk::Format::BC1_RGB_UNORM_BLOCK
+        | vk::Format::BC1_RGB_SRGB_BLOCK
+        | vk::Format::BC1_RGBA_UNORM_BLOCK
+        | vk::Format::BC1_RGBA_SRGB_BLOCK
+        | vk::Format::BC4_UNORM_BLOCK
+        | vk::Format::BC4_SNORM_BLOCK
+        | vk::Format::ETC2_R8G8B8_UNORM_BLOCK
+        | vk::Format::ETC2_R8G8B8_SRGB_BLOCK
+        | vk::Format::ETC2_R8G8B8A1_UNORM_BLOCK
+        | vk::Format::ETC2_R8G8B8A1_SRGB_BLOCK
+        | vk::Format::EAC_R11_UNORM_BLOCK
+        | vk::Format::EAC_R11_SNORM_BLOCK => 8,
+        vk::Format::BC2_UNORM_BLOCK
+        | vk::Format::BC2_SRGB_BLOCK
+        | vk::Format::BC3_UNORM_BLOCK
+        | vk::Format::BC3_SRGB_BLOCK
+        | vk::Format::BC5_UNORM_BLOCK
+        | vk::Format::BC5_SNORM_BLOCK
+        | vk::Format::BC6H_UFLOAT_BLOCK
+        | vk::Format::BC6H_SFLOAT_BLOCK
+        | vk::Format::BC7_UNORM_BLOCK
+        | vk::Format::BC7_SRGB_BLOCK
+        | vk::Format::ETC2_R8G8B8A8_UNORM_BLOCK
+        | vk::Format::ETC2_R8G8B8A8_SRGB_BLOCK
+        | vk::Format::EAC_R11G11_UNORM_BLOCK
+        | vk::Format::EAC_R11G11_SNORM_BLOCK => 16,
+        vk::Format::ASTC_4X4_SFLOAT_BLOCK
+        | vk::Format::ASTC_4X4_UNORM_BLOCK
+        | vk::Format::ASTC_4X4_SRGB_BLOCK
+        | vk::Format::ASTC_5X4_SFLOAT_BLOCK
+        | vk::Format::ASTC_5X4_UNORM_BLOCK
+        | vk::Format::ASTC_5X4_SRGB_BLOCK
+        | vk::Format::ASTC_5X5_SFLOAT_BLOCK
+        | vk::Format::ASTC_5X5_UNORM_BLOCK
+        | vk::Format::ASTC_5X5_SRGB_BLOCK
+        | vk::Format::ASTC_6X5_SFLOAT_BLOCK
+        | vk::Format::ASTC_6X5_UNORM_BLOCK
+        | vk::Format::ASTC_6X5_SRGB_BLOCK
+        | vk::Format::ASTC_6X6_SFLOAT_BLOCK
+        | vk::Format::ASTC_6X6_UNORM_BLOCK
+        | vk::Format::ASTC_6X6_SRGB_BLOCK
+        | vk::Format::ASTC_8X5_SFLOAT_BLOCK
+        | vk::Format::ASTC_8X5_UNORM_BLOCK
+        | vk::Format::ASTC_8X5_SRGB_BLOCK
+        | vk::Format::ASTC_8X6_SFLOAT_BLOCK
+        | vk::Format::ASTC_8X6_UNORM_BLOCK
+        | vk::Format::ASTC_8X6_SRGB_BLOCK
+        | vk::Format::ASTC_8X8_SFLOAT_BLOCK
+        | vk::Format::ASTC_8X8_UNORM_BLOCK
+        | vk::Format::ASTC_8X8_SRGB_BLOCK
+        | vk::Format::ASTC_10X5_SFLOAT_BLOCK
+        | vk::Format::ASTC_10X5_UNORM_BLOCK
+        | vk::Format::ASTC_10X5_SRGB_BLOCK
+        | vk::Format::ASTC_10X6_SFLOAT_BLOCK
+        | vk::Format::ASTC_10X6_UNORM_BLOCK
+        | vk::Format::ASTC_10X6_SRGB_BLOCK
+        | vk::Format::ASTC_10X8_SFLOAT_BLOCK
+        | vk::Format::ASTC_10X8_UNORM_BLOCK
+        | vk::Format::ASTC_10X8_SRGB_BLOCK
+        | vk::Format::ASTC_10X10_SFLOAT_BLOCK
+        | vk::Format::ASTC_10X10_UNORM_BLOCK
+        | vk::Format::ASTC_10X10_SRGB_BLOCK
+        | vk::Format::ASTC_12X10_SFLOAT_BLOCK
+        | vk::Format::ASTC_12X10_UNORM_BLOCK
+        | vk::Format::ASTC_12X10_SRGB_BLOCK
+        | vk::Format::ASTC_12X12_SFLOAT_BLOCK
+        | vk::Format::ASTC_12X12_UNORM_BLOCK
+        | vk::Format::ASTC_12X12_SRGB_BLOCK => 16,
+        vk::Format::G8B8G8R8_422_UNORM | vk::Format::B8G8R8G8_422_UNORM => 4,
+        vk::Format::G8_B8_R8_3PLANE_420_UNORM
+        | vk::Format::G8_B8R8_2PLANE_420_UNORM
+        | vk::Format::G8_B8_R8_3PLANE_422_UNORM
+        | vk::Format::G8_B8R8_2PLANE_422_UNORM
+        | vk::Format::G8_B8_R8_3PLANE_444_UNORM => 3,
+        vk::Format::R10X6G10X6B10X6A10X6_UNORM_4PACK16
+        | vk::Format::G10X6B10X6G10X6R10X6_422_UNORM_4PACK16
+        | vk::Format::B10X6G10X6R10X6G10X6_422_UNORM_4PACK16
+        | vk::Format::R12X4G12X4B12X4A12X4_UNORM_4PACK16
+        | vk::Format::G12X4B12X4G12X4R12X4_422_UNORM_4PACK16
+        | vk::Format::B12X4G12X4R12X4G12X4_422_UNORM_4PACK16
+        | vk::Format::G16B16G16R16_422_UNORM
+        | vk::Format::B16G16R16G16_422_UNORM => 8,
+        vk::Format::G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16
+        | vk::Format::G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16
+        | vk::Format::G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16
+        | vk::Format::G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16
+        | vk::Format::G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16
+        | vk::Format::G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16
+        | vk::Format::G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16
+        | vk::Format::G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16
+        | vk::Format::G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16
+        | vk::Format::G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16
+        | vk::Format::G16_B16_R16_3PLANE_420_UNORM
+        | vk::Format::G16_B16R16_2PLANE_420_UNORM
+        | vk::Format::G16_B16_R16_3PLANE_422_UNORM
+        | vk::Format::G16_B16R16_2PLANE_422_UNORM
+        | vk::Format::G16_B16_R16_3PLANE_444_UNORM => 6,
+        vk::Format::PVRTC1_2BPP_UNORM_BLOCK_IMG
+        | vk::Format::PVRTC1_2BPP_SRGB_BLOCK_IMG
+        | vk::Format::PVRTC1_4BPP_UNORM_BLOCK_IMG
+        | vk::Format::PVRTC1_4BPP_SRGB_BLOCK_IMG
+        | vk::Format::PVRTC2_2BPP_UNORM_BLOCK_IMG
+        | vk::Format::PVRTC2_2BPP_SRGB_BLOCK_IMG
+        | vk::Format::PVRTC2_4BPP_UNORM_BLOCK_IMG
+        | vk::Format::PVRTC2_4BPP_SRGB_BLOCK_IMG => 8,
+        vk::Format::G8_B8R8_2PLANE_444_UNORM => 3,
+        vk::Format::G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16
+        | vk::Format::G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16
+        | vk::Format::G16_B16R16_2PLANE_444_UNORM => 6,
+        _ => {
+            // Remaining formats should be implemented in the future
+            unimplemented!()
+        }
+    }
+}
+
+/// Returns the dimension of a block of texels for the given Vulkan format.
+/// Uncompressed formats typically have a block dimension of `(1, 1)`.
+/// See [Representation and Texel Block Size](https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#texel-block-size)
+pub const fn format_texel_block_dimensions(vk_format: vk::Format) -> (u32, u32) {
+    match vk_format {
+        vk::Format::R4G4_UNORM_PACK8
+        | vk::Format::R8_UNORM
+        | vk::Format::R8_SNORM
+        | vk::Format::R8_USCALED
+        | vk::Format::R8_SSCALED
+        | vk::Format::R8_UINT
+        | vk::Format::R8_SINT
+        | vk::Format::R8_SRGB
+        | vk::Format::A1B5G5R5_UNORM_PACK16_KHR
+        | vk::Format::R10X6_UNORM_PACK16
+        | vk::Format::R12X4_UNORM_PACK16
+        | vk::Format::A4R4G4B4_UNORM_PACK16
+        | vk::Format::A4B4G4R4_UNORM_PACK16
+        | vk::Format::R4G4B4A4_UNORM_PACK16
+        | vk::Format::B4G4R4A4_UNORM_PACK16
+        | vk::Format::R5G6B5_UNORM_PACK16
+        | vk::Format::B5G6R5_UNORM_PACK16
+        | vk::Format::R5G5B5A1_UNORM_PACK16
+        | vk::Format::B5G5R5A1_UNORM_PACK16
+        | vk::Format::A1R5G5B5_UNORM_PACK16
+        | vk::Format::R8G8_UNORM
+        | vk::Format::R8G8_SNORM
+        | vk::Format::R8G8_USCALED
+        | vk::Format::R8G8_SSCALED
+        | vk::Format::R8G8_UINT
+        | vk::Format::R8G8_SINT
+        | vk::Format::R8G8_SRGB
+        | vk::Format::R16_UNORM
+        | vk::Format::R16_SNORM
+        | vk::Format::R16_USCALED
+        | vk::Format::R16_SSCALED
+        | vk::Format::R16_UINT
+        | vk::Format::R16_SINT
+        | vk::Format::R16_SFLOAT
+        | vk::Format::A8_UNORM_KHR
+        | vk::Format::R8G8B8_UNORM
+        | vk::Format::R8G8B8_SNORM
+        | vk::Format::R8G8B8_USCALED
+        | vk::Format::R8G8B8_SSCALED
+        | vk::Format::R8G8B8_UINT
+        | vk::Format::R8G8B8_SINT
+        | vk::Format::R8G8B8_SRGB
+        | vk::Format::B8G8R8_UNORM
+        | vk::Format::B8G8R8_SNORM
+        | vk::Format::B8G8R8_USCALED
+        | vk::Format::B8G8R8_SSCALED
+        | vk::Format::B8G8R8_UINT
+        | vk::Format::B8G8R8_SINT
+        | vk::Format::B8G8R8_SRGB
+        | vk::Format::R10X6G10X6_UNORM_2PACK16
+        | vk::Format::R12X4G12X4_UNORM_2PACK16
+        | vk::Format::R16G16_S10_5_NV
+        | vk::Format::R8G8B8A8_UNORM
+        | vk::Format::R8G8B8A8_SNORM
+        | vk::Format::R8G8B8A8_USCALED
+        | vk::Format::R8G8B8A8_SSCALED
+        | vk::Format::R8G8B8A8_UINT
+        | vk::Format::R8G8B8A8_SINT
+        | vk::Format::R8G8B8A8_SRGB
+        | vk::Format::B8G8R8A8_UNORM
+        | vk::Format::B8G8R8A8_SNORM
+        | vk::Format::B8G8R8A8_USCALED
+        | vk::Format::B8G8R8A8_SSCALED
+        | vk::Format::B8G8R8A8_UINT
+        | vk::Format::B8G8R8A8_SINT
+        | vk::Format::B8G8R8A8_SRGB
+        | vk::Format::A8B8G8R8_UNORM_PACK32
+        | vk::Format::A8B8G8R8_SNORM_PACK32
+        | vk::Format::A8B8G8R8_USCALED_PACK32
+        | vk::Format::A8B8G8R8_SSCALED_PACK32
+        | vk::Format::A8B8G8R8_UINT_PACK32
+        | vk::Format::A8B8G8R8_SINT_PACK32
+        | vk::Format::A8B8G8R8_SRGB_PACK32
+        | vk::Format::A2R10G10B10_UNORM_PACK32
+        | vk::Format::A2R10G10B10_SNORM_PACK32
+        | vk::Format::A2R10G10B10_USCALED_PACK32
+        | vk::Format::A2R10G10B10_SSCALED_PACK32
+        | vk::Format::A2R10G10B10_UINT_PACK32
+        | vk::Format::A2R10G10B10_SINT_PACK32
+        | vk::Format::A2B10G10R10_UNORM_PACK32
+        | vk::Format::A2B10G10R10_SNORM_PACK32
+        | vk::Format::A2B10G10R10_USCALED_PACK32
+        | vk::Format::A2B10G10R10_SSCALED_PACK32
+        | vk::Format::A2B10G10R10_UINT_PACK32
+        | vk::Format::A2B10G10R10_SINT_PACK32
+        | vk::Format::R16G16_UNORM
+        | vk::Format::R16G16_SNORM
+        | vk::Format::R16G16_USCALED
+        | vk::Format::R16G16_SSCALED
+        | vk::Format::R16G16_UINT
+        | vk::Format::R16G16_SINT
+        | vk::Format::R16G16_SFLOAT
+        | vk::Format::R32_UINT
+        | vk::Format::R32_SINT
+        | vk::Format::R32_SFLOAT
+        | vk::Format::B10G11R11_UFLOAT_PACK32
+        | vk::Format::E5B9G9R9_UFLOAT_PACK32
+        | vk::Format::R16G16B16_UNORM
+        | vk::Format::R16G16B16_SNORM
+        | vk::Format::R16G16B16_USCALED
+        | vk::Format::R16G16B16_SSCALED
+        | vk::Format::R16G16B16_UINT
+        | vk::Format::R16G16B16_SINT
+        | vk::Format::R16G16B16_SFLOAT
+        | vk::Format::R16G16B16A16_UNORM
+        | vk::Format::R16G16B16A16_SNORM
+        | vk::Format::R16G16B16A16_USCALED
+        | vk::Format::R16G16B16A16_SSCALED
+        | vk::Format::R16G16B16A16_UINT
+        | vk::Format::R16G16B16A16_SINT
+        | vk::Format::R16G16B16A16_SFLOAT
+        | vk::Format::R32G32_UINT
+        | vk::Format::R32G32_SINT
+        | vk::Format::R32G32_SFLOAT
+        | vk::Format::R64_UINT
+        | vk::Format::R64_SINT
+        | vk::Format::R64_SFLOAT
+        | vk::Format::R32G32B32_UINT
+        | vk::Format::R32G32B32_SINT
+        | vk::Format::R32G32B32_SFLOAT
+        | vk::Format::R32G32B32A32_UINT
+        | vk::Format::R32G32B32A32_SINT
+        | vk::Format::R32G32B32A32_SFLOAT
+        | vk::Format::R64G64_UINT
+        | vk::Format::R64G64_SINT
+        | vk::Format::R64G64_SFLOAT
+        | vk::Format::R64G64B64_UINT
+        | vk::Format::R64G64B64_SINT
+        | vk::Format::R64G64B64_SFLOAT
+        | vk::Format::R64G64B64A64_UINT
+        | vk::Format::R64G64B64A64_SINT
+        | vk::Format::R64G64B64A64_SFLOAT
+        | vk::Format::D16_UNORM
+        | vk::Format::X8_D24_UNORM_PACK32
+        | vk::Format::D32_SFLOAT
+        | vk::Format::S8_UINT
+        | vk::Format::D16_UNORM_S8_UINT
+        | vk::Format::D24_UNORM_S8_UINT
+        | vk::Format::D32_SFLOAT_S8_UINT => (1, 1),
+        vk::Format::BC1_RGB_UNORM_BLOCK
+        | vk::Format::BC1_RGB_SRGB_BLOCK
+        | vk::Format::BC1_RGBA_UNORM_BLOCK
+        | vk::Format::BC1_RGBA_SRGB_BLOCK
+        | vk::Format::BC2_UNORM_BLOCK
+        | vk::Format::BC2_SRGB_BLOCK
+        | vk::Format::BC3_UNORM_BLOCK
+        | vk::Format::BC3_SRGB_BLOCK
+        | vk::Format::BC4_UNORM_BLOCK
+        | vk::Format::BC4_SNORM_BLOCK
+        | vk::Format::BC5_UNORM_BLOCK
+        | vk::Format::BC5_SNORM_BLOCK
+        | vk::Format::BC6H_UFLOAT_BLOCK
+        | vk::Format::BC6H_SFLOAT_BLOCK
+        | vk::Format::BC7_UNORM_BLOCK
+        | vk::Format::BC7_SRGB_BLOCK
+        | vk::Format::ETC2_R8G8B8_UNORM_BLOCK
+        | vk::Format::ETC2_R8G8B8_SRGB_BLOCK
+        | vk::Format::ETC2_R8G8B8A1_UNORM_BLOCK
+        | vk::Format::ETC2_R8G8B8A1_SRGB_BLOCK
+        | vk::Format::ETC2_R8G8B8A8_UNORM_BLOCK
+        | vk::Format::ETC2_R8G8B8A8_SRGB_BLOCK
+        | vk::Format::EAC_R11_UNORM_BLOCK
+        | vk::Format::EAC_R11_SNORM_BLOCK
+        | vk::Format::EAC_R11G11_UNORM_BLOCK
+        | vk::Format::EAC_R11G11_SNORM_BLOCK => (4, 4),
+        vk::Format::ASTC_4X4_SFLOAT_BLOCK
+        | vk::Format::ASTC_4X4_UNORM_BLOCK
+        | vk::Format::ASTC_4X4_SRGB_BLOCK => (4, 4),
+        vk::Format::ASTC_5X4_SFLOAT_BLOCK
+        | vk::Format::ASTC_5X4_UNORM_BLOCK
+        | vk::Format::ASTC_5X4_SRGB_BLOCK => (5, 4),
+        vk::Format::ASTC_5X5_SFLOAT_BLOCK
+        | vk::Format::ASTC_5X5_UNORM_BLOCK
+        | vk::Format::ASTC_5X5_SRGB_BLOCK => (5, 5),
+        vk::Format::ASTC_6X5_SFLOAT_BLOCK
+        | vk::Format::ASTC_6X5_UNORM_BLOCK
+        | vk::Format::ASTC_6X5_SRGB_BLOCK => (6, 5),
+        vk::Format::ASTC_6X6_SFLOAT_BLOCK
+        | vk::Format::ASTC_6X6_UNORM_BLOCK
+        | vk::Format::ASTC_6X6_SRGB_BLOCK => (6, 6),
+        vk::Format::ASTC_8X5_SFLOAT_BLOCK
+        | vk::Format::ASTC_8X5_UNORM_BLOCK
+        | vk::Format::ASTC_8X5_SRGB_BLOCK => (8, 5),
+        vk::Format::ASTC_8X6_SFLOAT_BLOCK
+        | vk::Format::ASTC_8X6_UNORM_BLOCK
+        | vk::Format::ASTC_8X6_SRGB_BLOCK => (8, 6),
+        vk::Format::ASTC_8X8_SFLOAT_BLOCK
+        | vk::Format::ASTC_8X8_UNORM_BLOCK
+        | vk::Format::ASTC_8X8_SRGB_BLOCK => (8, 8),
+        vk::Format::ASTC_10X5_SFLOAT_BLOCK
+        | vk::Format::ASTC_10X5_UNORM_BLOCK
+        | vk::Format::ASTC_10X5_SRGB_BLOCK => (10, 5),
+        vk::Format::ASTC_10X6_SFLOAT_BLOCK
+        | vk::Format::ASTC_10X6_UNORM_BLOCK
+        | vk::Format::ASTC_10X6_SRGB_BLOCK => (10, 6),
+        vk::Format::ASTC_10X8_SFLOAT_BLOCK
+        | vk::Format::ASTC_10X8_UNORM_BLOCK
+        | vk::Format::ASTC_10X8_SRGB_BLOCK => (10, 8),
+        vk::Format::ASTC_10X10_SFLOAT_BLOCK
+        | vk::Format::ASTC_10X10_UNORM_BLOCK
+        | vk::Format::ASTC_10X10_SRGB_BLOCK => (10, 10),
+        vk::Format::ASTC_12X10_SFLOAT_BLOCK
+        | vk::Format::ASTC_12X10_UNORM_BLOCK
+        | vk::Format::ASTC_12X10_SRGB_BLOCK => (12, 10),
+        vk::Format::ASTC_12X12_SFLOAT_BLOCK
+        | vk::Format::ASTC_12X12_UNORM_BLOCK
+        | vk::Format::ASTC_12X12_SRGB_BLOCK => (12, 12),
+        vk::Format::G8B8G8R8_422_UNORM | vk::Format::B8G8R8G8_422_UNORM => (2, 1),
+        vk::Format::G8_B8_R8_3PLANE_420_UNORM
+        | vk::Format::G8_B8R8_2PLANE_420_UNORM
+        | vk::Format::G8_B8_R8_3PLANE_422_UNORM
+        | vk::Format::G8_B8R8_2PLANE_422_UNORM
+        | vk::Format::G8_B8_R8_3PLANE_444_UNORM
+        | vk::Format::R10X6G10X6B10X6A10X6_UNORM_4PACK16
+        | vk::Format::G10X6B10X6G10X6R10X6_422_UNORM_4PACK16
+        | vk::Format::B10X6G10X6R10X6G10X6_422_UNORM_4PACK16
+        | vk::Format::G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16
+        | vk::Format::G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16
+        | vk::Format::G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16
+        | vk::Format::G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16
+        | vk::Format::G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16
+        | vk::Format::R12X4G12X4B12X4A12X4_UNORM_4PACK16
+        | vk::Format::G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16
+        | vk::Format::G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16
+        | vk::Format::G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16
+        | vk::Format::G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16
+        | vk::Format::G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16
+        | vk::Format::G16_B16_R16_3PLANE_420_UNORM
+        | vk::Format::G16_B16R16_2PLANE_420_UNORM
+        | vk::Format::G16_B16_R16_3PLANE_422_UNORM
+        | vk::Format::G16_B16R16_2PLANE_422_UNORM
+        | vk::Format::G16_B16_R16_3PLANE_444_UNORM
+        | vk::Format::G8_B8R8_2PLANE_444_UNORM
+        | vk::Format::G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16
+        | vk::Format::G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16
+        | vk::Format::G16_B16R16_2PLANE_444_UNORM => (1, 1),
+        vk::Format::G12X4B12X4G12X4R12X4_422_UNORM_4PACK16
+        | vk::Format::B12X4G12X4R12X4G12X4_422_UNORM_4PACK16
+        | vk::Format::G16B16G16R16_422_UNORM
+        | vk::Format::B16G16R16G16_422_UNORM => (2, 1),
+        vk::Format::PVRTC1_2BPP_UNORM_BLOCK_IMG
+        | vk::Format::PVRTC1_2BPP_SRGB_BLOCK_IMG
+        | vk::Format::PVRTC2_2BPP_UNORM_BLOCK_IMG
+        | vk::Format::PVRTC2_2BPP_SRGB_BLOCK_IMG => (8, 4),
+        vk::Format::PVRTC1_4BPP_UNORM_BLOCK_IMG
+        | vk::Format::PVRTC1_4BPP_SRGB_BLOCK_IMG
+        | vk::Format::PVRTC2_4BPP_UNORM_BLOCK_IMG
+        | vk::Format::PVRTC2_4BPP_SRGB_BLOCK_IMG => (4, 4),
         _ => {
             // Remaining formats should be implemented in the future
             unimplemented!()

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -355,10 +355,10 @@ pub const fn format_texel_block_size(fmt: vk::Format) -> u32 {
     }
 }
 
-/// Returns the dimension of a block of texels for the given Vulkan format.
-/// Uncompressed formats typically have a block dimension of `(1, 1)`.
+/// Returns the extent of a block of texels for the given Vulkan format.
+/// Uncompressed formats typically have a block extent of `(1, 1)`.
 /// See [Representation and Texel Block Size](https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#texel-block-size)
-pub const fn format_texel_block_dimensions(vk_format: vk::Format) -> (u32, u32) {
+pub const fn format_texel_block_extent(vk_format: vk::Format) -> (u32, u32) {
     match vk_format {
         vk::Format::R4G4_UNORM_PACK8
         | vk::Format::R8_UNORM

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -34,7 +34,7 @@ use {
         buffer::Buffer,
         compute::ComputePipeline,
         device::Device,
-        format_aspect_mask, format_texel_block_dimensions, format_texel_block_size,
+        format_aspect_mask, format_texel_block_extent, format_texel_block_size,
         graphic::{DepthStencilMode, GraphicPipeline},
         image::{ImageType, ImageViewInfo, SampleCount},
         image_subresource_range_from_layers,
@@ -654,7 +654,7 @@ impl RenderGraph {
 
         for region in regions.as_ref() {
             let block_bytes_size = format_texel_block_size(dst_info.fmt);
-            let (block_height, block_width) = format_texel_block_dimensions(dst_info.fmt);
+            let (block_height, block_width) = format_texel_block_extent(dst_info.fmt);
             let data_size = block_bytes_size
                 * (region.buffer_row_length / block_width)
                 * (region.buffer_image_height / block_height);
@@ -851,7 +851,7 @@ impl RenderGraph {
 
         for region in regions.as_ref() {
             let block_bytes_size = format_texel_block_size(src_info.fmt);
-            let (block_height, block_width) = format_texel_block_dimensions(src_info.fmt);
+            let (block_height, block_width) = format_texel_block_extent(src_info.fmt);
             let data_size = block_bytes_size
                 * (region.buffer_row_length / block_width)
                 * (region.buffer_image_height / block_height);

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -34,7 +34,7 @@ use {
         buffer::Buffer,
         compute::ComputePipeline,
         device::Device,
-        format_aspect_mask, format_texel_block_size,
+        format_aspect_mask, format_texel_block_dimensions, format_texel_block_size,
         graphic::{DepthStencilMode, GraphicPipeline},
         image::{ImageType, ImageViewInfo, SampleCount},
         image_subresource_range_from_layers,
@@ -653,16 +653,17 @@ impl RenderGraph {
         let mut pass = self.begin_pass("copy buffer to image");
 
         for region in regions.as_ref() {
+            let block_bytes_size = format_texel_block_size(dst_info.fmt);
+            let (block_height, block_width) = format_texel_block_dimensions(dst_info.fmt);
+            let data_size = block_bytes_size
+                * (region.buffer_row_length / block_width)
+                * (region.buffer_image_height / block_height);
+
             pass = pass
                 .access_node_subrange(
                     src_node,
                     AccessType::TransferRead,
-                    region.buffer_offset
-                        ..region.buffer_offset
-                            + (region.buffer_row_length
-                                * format_texel_block_size(dst_info.fmt)
-                                * region.buffer_image_height)
-                                as vk::DeviceSize,
+                    region.buffer_offset..region.buffer_offset + data_size as vk::DeviceSize,
                 )
                 .access_node_subrange(
                     dst_node,
@@ -849,6 +850,12 @@ impl RenderGraph {
         let mut pass = self.begin_pass("copy image to buffer");
 
         for region in regions.as_ref() {
+            let block_bytes_size = format_texel_block_size(src_info.fmt);
+            let (block_height, block_width) = format_texel_block_dimensions(src_info.fmt);
+            let data_size = block_bytes_size
+                * (region.buffer_row_length / block_width)
+                * (region.buffer_image_height / block_height);
+
             pass = pass
                 .access_node_subrange(
                     src_node,
@@ -858,12 +865,7 @@ impl RenderGraph {
                 .access_node_subrange(
                     dst_node,
                     AccessType::TransferWrite,
-                    region.buffer_offset
-                        ..region.buffer_offset
-                            + (region.buffer_row_length
-                                * format_texel_block_size(src_info.fmt)
-                                * region.buffer_image_height)
-                                as vk::DeviceSize,
+                    region.buffer_offset..region.buffer_offset + data_size as vk::DeviceSize,
                 );
         }
 


### PR DESCRIPTION
Added support for block formats in `format_texel_block_size()`, `copy_buffer_to_image_regions()`, `copy_image_to_buffer_regions()`. Added `format_texel_block_dimensions()`.

Added remaining formats in https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#texel-block-size

Have only tested with BCn textures.