### PR TITLE
Make present mode configurable

### DIFF
--- a/contrib/screen-13-window/src/lib.rs
+++ b/contrib/screen-13-window/src/lib.rs
@@ -3,13 +3,13 @@ mod frame;
 pub use self::frame::FrameContext;
 
 use {
-    log::{info,trace, warn},
+    log::{info, trace, warn},
     screen_13::{
         driver::{
             ash::vk,
             device::{Device, DeviceInfo},
             surface::Surface,
-            swapchain::{Swapchain, SwapchainInfo},
+            swapchain::{PresentMode, Swapchain, SwapchainInfo},
             DriverError,
         },
         graph::RenderGraph,
@@ -90,7 +90,11 @@ impl Window {
                 }
 
                 if let Some(v_sync) = self.data.v_sync {
-                    swapchain_info = swapchain_info.sync_display(v_sync);
+                    swapchain_info = if v_sync {
+                        swapchain_info.present_mode(PresentMode::FifoRelaxed)
+                    } else {
+                        swapchain_info.present_mode(PresentMode::Mailbox)
+                    };
                 }
 
                 let swapchain = Swapchain::new(&self.device, surface, swapchain_info)?;

--- a/contrib/screen-13-window/src/lib.rs
+++ b/contrib/screen-13-window/src/lib.rs
@@ -9,7 +9,7 @@ use {
             ash::vk,
             device::{Device, DeviceInfo},
             surface::Surface,
-            swapchain::{PresentMode, Swapchain, SwapchainInfo},
+            swapchain::{Swapchain, SwapchainInfo},
             DriverError,
         },
         graph::RenderGraph,
@@ -91,9 +91,15 @@ impl Window {
 
                 if let Some(v_sync) = self.data.v_sync {
                     swapchain_info = if v_sync {
-                        swapchain_info.present_mode(PresentMode::FifoRelaxed)
+                        swapchain_info.present_modes(vec![
+                            vk::PresentModeKHR::FIFO_RELAXED,
+                            vk::PresentModeKHR::FIFO,
+                        ])
                     } else {
-                        swapchain_info.present_mode(PresentMode::Mailbox)
+                        swapchain_info.present_modes(vec![
+                            vk::PresentModeKHR::MAILBOX,
+                            vk::PresentModeKHR::IMMEDIATE,
+                        ])
                     };
                 }
 

--- a/src/driver/swapchain.rs
+++ b/src/driver/swapchain.rs
@@ -575,6 +575,7 @@ pub struct SwapchainInfo {
     ///
     /// * **Tearing**: No tearing will be observed.
     /// * **Also known as**: "Fast Vsync"
+    #[builder(default = vec![vk::PresentModeKHR::FIFO_RELAXED, vk::PresentModeKHR::FIFO])]
     pub present_modes: Vec<vk::PresentModeKHR>,
 
     /// The initial width of the surface.
@@ -651,7 +652,7 @@ mod tests {
     #[test]
     pub fn swapchain_info() {
         let info = Info::new(20, 24, vk::SurfaceFormatKHR::default());
-        let builder = info.to_builder().build();
+        let builder = info.clone().to_builder().build();
 
         assert_eq!(info, builder);
     }


### PR DESCRIPTION
Sometimes a bit more flexibility is needed here than just vsync on/off for testing, and occasionally in video games players may also want more control.

Inspired by https://github.com/gfx-rs/wgpu/blob/v25/wgpu-types/src/lib.rs#L5125 but didn't include `AutoVsync` or `AutoNoVsync`, and rather opted for making all of the modes non-fallible with appropriate fallback options.

Didn't update `WindowData` or `WindowBuilder` in this PR since I wanted to get your opinion first on the general direction first. (I also don't personally use `WindowData` or `WindowBuilder` so I wouldn't need a change with those to accomplish what I'm trying to do)