### PR TITLE
Allow dynamic linking of molten-vk on MacOS.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ description = "An easy-to-use Vulkan rendering engine in the spirit of QBasic."
 
 [features]
 default = []
+macos-dynamic-molten-vk=[]
 profile-with-puffin = ["profiling/profile-with-puffin"]
 profile-with-optick = ["profiling/profile-with-optick"]
 profile-with-superluminal = ["profiling/profile-with-superluminal"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,18 @@ categories = ["game-development", "multimedia::images", "rendering::engine"]
 description = "An easy-to-use Vulkan rendering engine in the spirit of QBasic."
 
 [features]
-default = []
-macos-dynamic-molten-vk=[]
+default = ["loaded"]
+ash-molten=["loaded", "dep:ash-molten"]
+linked=["ash/linked"]
+loaded=["ash/loaded"]
+
 profile-with-puffin = ["profiling/profile-with-puffin"]
 profile-with-optick = ["profiling/profile-with-optick"]
 profile-with-superluminal = ["profiling/profile-with-superluminal"]
 profile-with-tracy = ["profiling/profile-with-tracy"]
 
 [dependencies]
-ash = "0.38"
+ash = { version = "0.38", default-features = false, features = ["debug", "std"] }
 ash-window = "0.13"
 derive_builder = "0.20"
 gpu-allocator = "0.28"
@@ -35,7 +38,7 @@ spirq = "1.2"
 vk-sync = { version = "0.5", package = "vk-sync-fork" }  # // SEE: https://github.com/gwihlidal/vk-sync-rs/pull/4 -> https://github.com/expenses/vk-sync-rs
 
 [target.'cfg(target_os = "macos")'.dependencies]
-ash-molten = "0.20"
+ash-molten = { version = "0.20", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/src/driver/device.rs
+++ b/src/driver/device.rs
@@ -75,7 +75,7 @@ impl Device {
     where
         F: FnOnce(vk::DeviceCreateInfo) -> ash::prelude::VkResult<ash::Device>,
     {
-        let mut enabled_ext_names = Vec::with_capacity(6);
+        let mut enabled_ext_names = Vec::with_capacity(7);
 
         if display_window {
             enabled_ext_names.push(khr::swapchain::NAME.as_ptr());
@@ -96,6 +96,12 @@ impl Device {
 
         if physical_device.index_type_uint8_features.index_type_uint8 {
             enabled_ext_names.push(ext::index_type_uint8::NAME.as_ptr());
+        }
+
+        // Molten-vk doesn't support the full Vulkan feature set, hence the portability subset extension must be enabled.
+        #[cfg(all(target_os = "macos", feature = "macos-dynamic-molten-vk"))]
+        {
+            enabled_ext_names.push(khr::portability_subset::NAME.as_ptr());
         }
 
         let priorities = repeat_n(

--- a/src/driver/device.rs
+++ b/src/driver/device.rs
@@ -99,7 +99,7 @@ impl Device {
         }
 
         // Molten-vk doesn't support the full Vulkan feature set, hence the portability subset extension must be enabled.
-        #[cfg(all(target_os = "macos", feature = "macos-dynamic-molten-vk"))]
+        #[cfg(all(target_os = "macos", feature = "loaded"))]
         {
             enabled_ext_names.push(khr::portability_subset::NAME.as_ptr());
         }

--- a/src/driver/instance.rs
+++ b/src/driver/instance.rs
@@ -11,7 +11,7 @@ use {
     },
 };
 
-#[cfg(any(not(target_os = "macos"), feature = "macos-dynamic-molten-vk"))]
+#[cfg(any(not(target_os = "macos"), feature = "loaded"))]
 use {
     log::{Level, Metadata, info, logger},
     std::{
@@ -25,7 +25,7 @@ use {
 #[cfg(target_os = "macos")]
 use std::env::set_var;
 
-#[cfg(any(not(target_os = "macos"), feature = "macos-dynamic-molten-vk"))]
+#[cfg(any(not(target_os = "macos"), feature = "loaded"))]
 unsafe extern "system" fn vulkan_debug_callback(
     _flags: vk::DebugReportFlagsEXT,
     _obj_type: vk::DebugReportObjectTypeEXT,
@@ -137,7 +137,7 @@ impl Instance {
         }
 
         // Link molten-vk dynamically if not on MacOS, or if explicitly requested.
-        #[cfg(any(not(target_os = "macos"), feature = "macos-dynamic-molten-vk"))]
+        #[cfg(any(not(target_os = "macos"), feature = "loaded"))]
         let entry = unsafe {
             Entry::load().map_err(|err| {
                 error!("Vulkan driver not found: {err}");
@@ -146,7 +146,7 @@ impl Instance {
             })?
         };
         // On MacOS, by default link molten-vk statically using ash-molten.
-        #[cfg(all(target_os = "macos", not(feature = "macos-dynamic-molten-vk")))]
+        #[cfg(all(target_os = "macos", not(feature = "loaded")))]
         let entry = ash_molten::load();
 
         #[allow(unused_mut)]
@@ -155,7 +155,7 @@ impl Instance {
         // If linking dynamically on MacOS, we require a few additional extensions.
         // Based on "Encountered VK_ERROR_INCOMPATIBLE_DRIVER" section in:
         // https://vulkan.lunarg.com/doc/view/latest/mac/getting_started.html
-        #[cfg(all(target_os = "macos", feature = "macos-dynamic-molten-vk"))]
+        #[cfg(all(target_os = "macos", feature = "loaded"))]
         {
             required_extensions.push(ash::khr::get_physical_device_properties2::NAME);
             required_extensions.push(ash::khr::portability_enumeration::NAME);
@@ -178,7 +178,7 @@ impl Instance {
             .enabled_extension_names(&instance_extensions);
 
         // Molten-vk doesn't support the full Vulkan feature set, hence the portability flag needs to be set.
-        #[cfg(all(target_os = "macos", feature = "macos-dynamic-molten-vk"))]
+        #[cfg(all(target_os = "macos", feature = "loaded"))]
         let instance_desc = instance_desc.flags(vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR);
 
         let instance = unsafe {
@@ -205,10 +205,10 @@ impl Instance {
 
         trace!("created a Vulkan instance");
 
-        #[cfg(all(target_os = "macos", not(feature = "macos-dynamic-molten-vk")))]
+        #[cfg(all(target_os = "macos", not(feature = "loaded")))]
         let (debug_loader, debug_callback, debug_utils) = (None, None, None);
 
-        #[cfg(any(not(target_os = "macos"), feature = "macos-dynamic-molten-vk"))]
+        #[cfg(any(not(target_os = "macos"), feature = "loaded"))]
         let (debug_loader, debug_callback, debug_utils) = if debug {
             let debug_info = vk::DebugReportCallbackCreateInfoEXT {
                 flags: vk::DebugReportFlagsEXT::ERROR
@@ -275,7 +275,7 @@ impl Instance {
     ) -> Vec<*const c_char> {
         if cfg!(all(
             target_os = "macos",
-            not(feature = "macos-dynamic-molten-vk")
+            not(feature = "loaded")
         )) {
             vec![]
         } else {
@@ -299,7 +299,7 @@ impl Instance {
     ) -> Vec<CString> {
         if cfg!(all(
             target_os = "macos",
-            not(feature = "macos-dynamic-molten-vk")
+            not(feature = "loaded")
         )) {
             vec![]
         } else {


### PR DESCRIPTION
I wanted to use Vulkan validation layers on MacOS. The changes below are what's necessary to dynamically link Vulkan from an installed Vulkan SDK. 

I've moved these changes behind a new feature-flag, to keep the static linking behavior as default on MacOS. 

Please take a look :)