### PR TITLE
Change `i8` character type to `c_char`

### DIFF
--- a/src/driver/instance.rs
+++ b/src/driver/instance.rs
@@ -155,7 +155,7 @@ impl Instance {
             .chain(unsafe { Self::extension_names(debug).into_iter() })
             .collect::<Box<[_]>>();
         let layer_names = Self::layer_names(debug);
-        let layer_names: Vec<*const i8> = layer_names
+        let layer_names: Vec<*const c_char> = layer_names
             .iter()
             .map(|raw_name| raw_name.as_ptr())
             .collect();

--- a/src/driver/physical_device.rs
+++ b/src/driver/physical_device.rs
@@ -6,7 +6,7 @@ use {
     log::{debug, error},
     std::{
         collections::HashSet,
-        ffi::CStr,
+        ffi::{CStr, c_char},
         fmt::{Debug, Formatter},
         ops::Deref,
     },
@@ -14,7 +14,7 @@ use {
 
 // TODO: There is a bunch of unsafe cstr handling here - does not check for null-termination
 
-fn vk_cstr_to_string_lossy(cstr: &[i8]) -> String {
+fn vk_cstr_to_string_lossy(cstr: &[c_char]) -> String {
     unsafe { CStr::from_ptr(cstr.as_ptr()) }
         .to_string_lossy()
         .to_string()


### PR DESCRIPTION
This enables `screen-13` to compile on Android and other platforms where the character type isn't signed. For other platforms, this should change nothing.